### PR TITLE
Support multiple licenses and SPDX expressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function getLicenses(pkg) {
             license = [license];
         }
         return license.map(l => {
-            if (spdxLicenses.some(v => license.includes(v))) {
+            if (spdxLicenses.some(v => { return l === v; })) {
                 return { id : l };
             } else {
                 return { name : l };


### PR DESCRIPTION
This fixes two issues:

```
 "license": [
    "MIT",
    "Apache2"
  ]
```
This would always return true, cause it checks array membership and MIT is a valid SPDX license but Apache2 is not, which would cause a rejected bom from dependency-track. This pr will send MIT in the id field but Apache2 in the name field. Example from the node module pause-stream.

```
 "license": "(0BSD OR MIT)",
```
Needs to be passed in the name field as well. Example from the node module pikaday

SPDX expressions will be supported in 3.2 of dependency track, so this will need to be updated accordingly.


