### PR TITLE
Case nunjucks 1.3.4 -> license is object array

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ function createChild(name, value, depth) {
     if (name === "value") return value;
     if (Array.isArray(value)) return `<${name}>${value.map(v => js2Xml(v, depth + 1)).join('')}</${name}>`;
     if (['boolean', 'string', 'number'].includes(typeof value)) return `<${name}>${value}</${name}>`;
+    if (['object'].includes(typeof value)) return `<${name}>${value.type}</${name}>`;    
     //console.log(name, value);
     throw new Error("Unexpected child: " + name + " " + (typeof value) );
 }


### PR DESCRIPTION
"license": [
    {
      "type": "BSD",
      "url": "https://github.com/mozilla/nunjucks/blob/master/LICENSE"
    }
  ],

This raise an exception "throw new Error("Unexpected child: " + name + " " + (typeof value) );" due to the check which is only on 'boolean', 'string', 'number'.

