### PR TITLE
Exclude extraneous packages from BoM file

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,9 @@ function listComponents(pkg) {
  * Given the specified package, create a CycloneDX component and add it to the list.
  */
 function addComponent(pkg, list, isRootPkg = false) {
+    //read-installed with default options marks devDependencies as extraneous
+    //if a package is marked as extraneous, do not include it as a component
+    if(pkg.extraneous) return;
     if(!isRootPkg) {
         let pkgIdentifier = parsePackageJsonName(pkg.name);
         let group = pkgIdentifier.scope;


### PR DESCRIPTION
read-installed traverses all folders within the node_modules folder and marks any devDependencies as extraneous when the `dev` option is to false (this is also the default value). Since the current expectation from this module is to not include any devDependencies regardless of whether they are in the node_modules directory, I've created this PR to exclude all extraneous packages.

If there is a need to have devDependencies as part of the BoM, a new flag should be introduced that would set the `dev` option of read-installed to true,