### PR TITLE
Fix -d option ignoring the next argument

### DIFF
--- a/bin/cyclonedx-bom
+++ b/bin/cyclonedx-bom
@@ -40,7 +40,7 @@ let d = arguments.indexOf("-d");
 let options = {};
 if (d > -1) {
   options.dev = true;
-  arguments = arguments.slice(0,d).concat(arguments.slice(d+2));
+  arguments = arguments.slice(0,d).concat(arguments.slice(d+1));
 }
 
 


### PR DESCRIPTION
https://github.com/CycloneDX/cyclonedx-node-module/pull/14 introduced a bug where using `-d` option to include devDependencies ignored the next argument. For example, `cyclonedx-bom -d path/to/package -o bom.xml` would end up ignoring the given path and create the bill of materials for current working directory.

This PR fixes the problem and moves the "argument cursor" only one step for `-d` flag.