### PR TITLE
Add support for multiple additional bills of materials

### DIFF
--- a/bin/cyclonedx-bom
+++ b/bin/cyclonedx-bom
@@ -22,11 +22,12 @@ if (arguments.includes("-h") || unknownOptions.length > 0) {
 
 let a = arguments.indexOf("-a");
 let additional = "";
-if (a > -1) {
-    additional = fs.readFileSync(arguments[a+1], "utf-8")
+while (a > -1) {
+    additional += fs.readFileSync(arguments[a+1], "utf-8")
         .replace(/^[\s\S]*?<components>/, "")
-        .replace(/<.components>[\s]*?<\/bom>[\s]*?$/, "");
+        .replace(/[\s]*?<.components>[\s]*?<\/bom>[\s]*?$/, "");
     arguments = arguments.slice(0,a).concat(arguments.slice(a+2));
+    a = arguments.indexOf("-a");
 }
 
 let o = arguments.indexOf("-o");


### PR DESCRIPTION
This PR adds support for including additional modules from multiple BoM files in a single command. This is useful in JavaScript projects where frontend and backend have their own package.json and node_modules.

Usage
```sh
cyclonedx-bom -o out.xml -a frontend/bom.xml -a backend/bom.xml
```