### PR TITLE
Expose listComponents in public API

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function getLicenses(pkg) {
  * For all modules in the specified package, creates a list of
  * component objects from each one.
  */
+exports.listComponents = listComponents;
 function listComponents(pkg) {
     let list = {};
     let isRootPkg = true;
@@ -85,8 +86,7 @@ function createChild(name, value, depth) {
     if (name === "value") return value;
     if (Array.isArray(value)) return `<${name}>${value.map(v => js2Xml(v, depth + 1)).join('')}</${name}>`;
     if (['boolean', 'string', 'number'].includes(typeof value)) return `<${name}>${value}</${name}>`;
-    if (['object'].includes(typeof value)) return `<${name}>${value.type}</${name}>`;    
-    //console.log(name, value);
+    if (['object'].includes(typeof value)) return `<${name}>${value.type}</${name}>`;
     throw new Error("Unexpected child: " + name + " " + (typeof value) );
 }
 


### PR DESCRIPTION
Export `listComponents` in public API to enable better creating BOMs in Node.js (command line) applications.

## Example

Create a single BOM that includes components from 2 subpackages.

```js
const { listComponents } = require('@cyclonedx/bom');
const { promisify } = require('util');
const readInstalled = promisify(require('read-installed'));


async function createCombinedBOM() {
  const jsComponents = listComponents([
    ...(await readInstalled('path/To/Subpackage1')),
    ...(await readInstalled('path/To/Subpackage2'))
  ]);
  
  // Create the XML and write to file...
}

```