### PR TITLE
Added cli option to print version number

### DIFF
--- a/bin/cyclonedx-bom
+++ b/bin/cyclonedx-bom
@@ -2,11 +2,12 @@
 
 const bom = require("../index.js");
 const fs = require("fs");
+const path = require("path");
 const xmlFormat = require("prettify-xml");
 const xmlOptions = {indent: 4, newline: "\n"};
 
 let arguments = process.argv.slice(2);
-let unknownOptions = arguments.filter(x => x.startsWith("-")).filter(x => !["-h", "-a", "-o", "-v10", "-v11", "-ns", "-d"].includes(x));
+let unknownOptions = arguments.filter(x => x.startsWith("-")).filter(x => !["-h", "-a", "-o", "-v10", "-v11", "-ns", "-d", "--version"].includes(x));
 if (arguments.includes("-h") || unknownOptions.length > 0) {
     if (unknownOptions.length > 0) {
         console.warn("ERROR: Unknown option(s) " + unknownOptions.join(" ") );
@@ -20,11 +21,21 @@ if (arguments.includes("-h") || unknownOptions.length > 0) {
     console.log("  -v11      - generate CycloneDX v1.1 (default)");
     console.log("  -ns       - do not generate bom serial number (schema v1.1 or higher)");
     console.log("  -d        - include devDependencies");
+    console.log("  --version - print version number");
     process.exit(0);
 }
 
 let schemaVersion = "1.1"; // The default
 let includeBomSerialNumber = true; // The default
+
+let printVersion = arguments.indexOf("--version");
+if (printVersion > -1) {
+    const packageJsonAsString = fs.readFileSync(path.join(__dirname, '../', 'package.json'), "utf-8");
+    const packageJson = JSON.parse(packageJsonAsString);
+
+    console.log(packageJson.version);
+    process.exit(0);
+}
 
 let v10 = arguments.indexOf("-v10");
 if (v10 > -1) {
@@ -69,9 +80,9 @@ if (d > -1) {
 }
 
 
-let path = arguments[0] || '.';
+let filePath = arguments[0] || '.';
 
-bom.createbom(schemaVersion, includeBomSerialNumber, path, options, (err, bom) => {
+bom.createbom(schemaVersion, includeBomSerialNumber, filePath, options, (err, bom) => {
     bom = xmlFormat(bom.replace("</components></bom>", additional + "</components></bom>"), xmlOptions);
     if (out) {
         fs.writeFile(out, bom, () => {});


### PR DESCRIPTION
There was no way of seing the version of the library that is in use so I added a cli option to achieve this. The standard convention of '--version' was used