### PR TITLE
Publish only relevant files to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,10 @@
     "read-installed": "^4.0.3",
     "ssri": "^6.0.0",
     "uuid": "^3.3.2"
-  }
+  },
+  "files": [
+    "index.js",
+    "bin/",
+    "spdx-licenses.json"
+  ]
 }


### PR DESCRIPTION
Fixes #23 

Only publish files that are needed for the package usage. This will exclude .git directory, possible bom.xml and files/directories left by text editors. See the screenshot of the package contents when running `npm pack` and please find the attached package that `npm pack` produced (ZIPped to be able to attach it to GitHub).

![Screenshot 2019-07-03 at 14 30 56](https://user-images.githubusercontent.com/8571541/60588382-821fe500-9d9f-11e9-93e5-65f54e5d391f.png)

[cyclonedx-bom-1.0.0.tgz.zip](https://github.com/CycloneDX/cyclonedx-node-module/files/3354771/cyclonedx-bom-1.0.0.tgz.zip)
