### PR TITLE
Handle incomplete top level component metadata

### DIFF
--- a/model/Component.js
+++ b/model/Component.js
@@ -40,7 +40,8 @@ class Component extends CycloneDXObject {
       this._licenses = new LicenseChoice(pkg, includeLicenseText);
       this._hashes = new HashList(pkg);
       this._externalReferences = new ExternalReferenceList(pkg);
-      this._purl = new PackageURL('npm', this._group, this._name, this._version, null, null).toString();
+      if (this._name && this._version)
+        this._purl = new PackageURL('npm', this._group, this._name, this._version, null, null).toString();
       this._bomRef = this._purl;
     } else {
       this._hashes = new HashList();


### PR DESCRIPTION
Fix for issue #74 

The problem is caused by trying to populate metadata for the project the SBOM is being generated for. As part of this a package URL is being generated but the required information may not be present. Especially if the node project isn't being published as a package.