### PR TITLE
Workaround for default values not being set

### DIFF
--- a/bin/cyclonedx-bom
+++ b/bin/cyclonedx-bom
@@ -45,8 +45,8 @@ function commaSeparatedList(value, previous) {
 let filePath = commander.args[0] || '.';
 let includeSerialNumber = commander.serialNumber;
 let includeLicenseText = commander.includeLicenseText;
-let output = commander.output;
-let componentType = commander.type;
+let output = commander.output || "bom.xml";
+let componentType = commander.type || "library";
 
 if (Component.supportedComponentTypes().indexOf(componentType) === -1) {
     throw "Unsupported component type. Supported types are " + Component.supportedComponentTypes().toString();


### PR DESCRIPTION
Temporary fix for #139 until it can be determined why commander isn't setting default option values.