### PR TITLE
Fixes problem with paths not beeing files

### DIFF
--- a/model/LicenseChoice.js
+++ b/model/LicenseChoice.js
@@ -78,7 +78,7 @@ class LicenseChoice extends CycloneDXObject {
       for (const licenseFilename of licenseFilenames) {
         for (const [licenseContentType, fileExtension] of Object.entries(licenseContentTypes)) {
           let licenseFilepath = `${pkg.realPath}/${licenseFilename}${licenseName}${fileExtension}`;
-          if (fs.existsSync(licenseFilepath)) {
+          if (fs.existsSync(licenseFilepath) && fs.lstatSync(licenseFilepath).isFile()) {
             // 'text/plain' is the default in the spec. No need to specify it.
             let contentType = (licenseContentType === 'text/plain') ? null : licenseContentType;
             licenseObject.attachmentText = this.createAttachmentText(licenseFilepath, contentType);


### PR DESCRIPTION
I encountered a problem within my dependencies where it seems that there are matching paths which were no valid files but directories. In order to prevent an error like this:

`$ cyclonedx-bom -l
internal/fs/utils.js:230
throw err;
^

Error: EISDIR: illegal operation on a directory, read
at Object.readSync (fs.js:564:3)
at tryReadSync (fs.js:349:20)
at Object.readFileSync (fs.js:386:19)
at LicenseChoice.createAttachmentText (/usr/local/lib/node_modules/@cyclonedx/bom/model/LicenseChoice.js:96:26)
`
I added a check for the path being a file.