### PR TITLE
Implement 'Include extraneous dependencies' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Creates CycloneDX Software Bill-of-Materials (SBOM) from Node.js projects
 Options:
   -v, --version              output the version number
   -d, --include-dev          Include devDependencies (default: false)
+  -e, --include-extraneous   Include extraneous dependencies (default: false)
   -l, --include-license-text Include full license text (default: false)
   -o, --output <output>      Write BOM to file (default: "bom.xml")
   -t, --type <type>          Project type (default: "library")

--- a/bin/cyclonedx-bom
+++ b/bin/cyclonedx-bom
@@ -36,6 +36,7 @@ cdx
   .version(program.version, '-v, --version')
   .argument('[path]', 'Path to analyze')
   .option('-d, --include-dev', "Include devDependencies", false)
+  .option('-e, --include-extraneous', "Include extraneous dependencies", false)
   .option('-l, --include-license-text', "Include full license text", false)
   .option('-o, --output <output>', "Write BOM to file", "bom.xml")
   .option('-t, --type <type>', "Project type", "library")
@@ -49,6 +50,7 @@ const options = cdx.opts();
 
 let includeSerialNumber = options.serialNumber;
 let includeLicenseText = options.includeLicenseText;
+let includeExtraneous = options.includeExtraneous;
 let output = options.output;
 let componentType = options.type;
 
@@ -62,7 +64,7 @@ let readInstalledOptions = { dev: options.includeDev };
 /**
  * Creates a Bom object and writes either XML or JSON.
  */
-bomHelpers.createbom(componentType, includeSerialNumber, includeLicenseText, filePath, readInstalledOptions, (err, bom) => {
+bomHelpers.createbom(componentType, includeSerialNumber, includeLicenseText, includeExtraneous, filePath, readInstalledOptions, (err, bom) => {
     if (bom.components.length === 0) {
         console.log("There are no components in the BOM. The project may not contain dependencies or node_modules does not exist. Executing `npm install` prior to CycloneDX may solve the issue.")
     }

--- a/index.js
+++ b/index.js
@@ -22,12 +22,12 @@ const Bom = require('./model/Bom');
 const fs = require('fs');
 
 
-exports.createbom = (componentType, includeSerialNumber, includeLicenseText, path, options, callback) => readInstalled(path, options, (err, pkgInfo) => {
+exports.createbom = (componentType, includeSerialNumber, includeLicenseText, includeExtraneous, path, options, callback) => readInstalled(path, options, (err, pkgInfo) => {
   let lockfile
   if (fs.existsSync(filePath.join(path, "package-lock.json"))) {
     lockfile = JSON.parse(fs.readFileSync(filePath.join(path, "package-lock.json")));
   }
-    let bom = new Bom(pkgInfo, componentType, includeSerialNumber, includeLicenseText, lockfile);
+    let bom = new Bom(pkgInfo, componentType, includeSerialNumber, includeLicenseText, includeExtraneous, lockfile);
     callback(null, bom);
 });
 

--- a/model/Bom.js
+++ b/model/Bom.js
@@ -26,7 +26,7 @@ const program = require('../package.json');
 
 class Bom extends CycloneDXObject {
 
-  constructor(pkg, componentType, includeSerialNumber = true, includeLicenseText = true, lockfile) {
+  constructor(pkg, componentType, includeSerialNumber = true, includeLicenseText = true, includeExtraneous = false, lockfile) {
     super();
     this._schemaVersion = "1.3";
     this._includeSerialNumber = includeSerialNumber;
@@ -37,7 +37,7 @@ class Bom extends CycloneDXObject {
     }
     if (pkg) {
       this._metadata = this.createMetadata(pkg, componentType);
-      this._components = this.listComponents(pkg, lockfile);
+      this._components = this.listComponents(pkg, includeExtraneous, lockfile);
     } else {
       this._components = [];
     }
@@ -57,20 +57,20 @@ class Bom extends CycloneDXObject {
    * For all modules in the specified package, creates a list of
    * component objects from each one.
    */
-  listComponents(pkg, lockfile) {
+  listComponents(pkg, includeExtraneous, lockfile) {
     let list = {};
     let isRootPkg = true;
-    this.createComponent(pkg, list, lockfile, isRootPkg);
+    this.createComponent(pkg, includeExtraneous, list, lockfile, isRootPkg);
     return Object.keys(list).map(k => (list[k]));
   }
 
   /**
    * Given the specified package, create a CycloneDX component and add it to the list.
    */
-  createComponent(pkg, list, lockfile, isRootPkg = false) {
+  createComponent(pkg, includeExtraneous, list, lockfile, isRootPkg = false) {
     //read-installed with default options marks devDependencies as extraneous
     //if a package is marked as extraneous, do not include it as a component
-    if(pkg.extraneous) return;
+    if(!includeExtraneous && pkg.extraneous) return;
     if(!isRootPkg) {
       let component = new Component(pkg, this.includeLicenseText, lockfile);
       if (component.externalReferences === undefined || component.externalReferences.length === 0) {
@@ -83,7 +83,7 @@ class Bom extends CycloneDXObject {
       Object.keys(pkg.dependencies)
         .map(x => pkg.dependencies[x])
         .filter(x => typeof(x) !== 'string') //remove cycles
-        .map(x => this.createComponent(x, list, lockfile));
+        .map(x => this.createComponent(x, includeExtraneous, list, lockfile));
     }
   }
 


### PR DESCRIPTION
Proposed workaround for #182 so user can include all extraneous dependencies in the bom.

Note that, this will not fix the core issue. Just a workaround for anyone who want to include the missing dependencies detected by this tool due to incorrect extraneous attribute by `read-installed`. It will include true positive extraneous dependency, but at least it's not missing the false positive extraneous dependency.