### PR TITLE
#194: adding standardjs can be run with npm run lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "cyclonedx-bom": "./bin/cyclonedx-bom"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "lint": "standard --fix"
   },
   "engines": {
     "node": ">=12.0.0"
@@ -67,6 +68,12 @@
     "spdx-licenses.json"
   ],
   "devDependencies": {
-    "jest": "^27.1.0"
+    "jest": "^27.1.0",
+    "standard": "^16.0.4"
+  },
+  "standard": {
+    "env": [
+      "jest"
+    ]
   }
 }


### PR DESCRIPTION
Signed-off-by: Anthony McKale <anthony@zapper.hodgers.com>

Fix #194

- added npm run lint
- added standardjs to dev dependencies
- have NOT added file linting changes, will let project owner do this as it will undoubtedly cause merge conflict fun