### PR TITLE
#193 : adding cyclonedx-node as a endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   ],
   "main": "index.js",
   "bin": {
-    "cyclonedx-bom": "./bin/cyclonedx-bom"
+    "cyclonedx-bom": "./bin/cyclonedx-bom",
+    "cyclonedx-node": "./bin/cyclonedx-bom"
   },
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
Fix #193 

ps unit tests didn't work for me locally, looks like the components isn't working for me with a clean install

```
createbom produces a BOM with development dependencies
createbom produces a BOM in JSON format
createbom produces a BOM in JSON format that includes hashes from package-lock.json
createbom produces a BOM when no package-lock.json is present

Test Suites: 1 failed, 4 passed, 5 total
Tests:       5 failed, 11 passed, 16 total
Snapshots:   5 failed, 1 passed, 6 total
```