### PR TITLE
Coding standards

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,8 +15,8 @@ env:
   REPORTS_DIR: CI_reports
 
 jobs:
-  test:
-    name: Test (node${{ matrix.node-version }}, ${{ matrix.os }})
+  unit-test:
+    name: UnitTest (node${{ matrix.node-version }}, ${{ matrix.os }})
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -51,7 +51,7 @@ jobs:
         working-directory: tests/with-packages
       - name: run tests
         run: >
-          npm run test --
+          npm run test:unit --
           --ci
           --no-cache
           --all
@@ -76,3 +76,24 @@ jobs:
           name: ${{ env.REPORTS_ARTIFACT }}
           path: ${{ env.REPORTS_DIR }}
           if-no-files-found: error
+
+  standards:
+    name: Standards
+    timeout-minutes: 30
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        # see https://github.com/actions/checkout
+        uses: actions/checkout@v2.4.0
+      - name: Setup Node.js ${{ matrix.node-version }}
+        ## see https://github.com/actions/setup-node
+        uses: actions/setup-node@v2.5.0
+        with:
+          node-version: '16' ## active LTS
+          cache: "npm"
+          cache-dependency-path: "**/package-lock.json"
+      - name: install project
+        run: npm ci
+      - name: run tests
+        run: npm run test:standard
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,14 @@ Feel free to open pull requests.
 
 To start developing simply run `npm i` to install dev-dependencies and tools.
 
+## Coding Style guide & standard
+
+Apply the coding style via
+
+```shell
+npm run cs-fix
+```
+
 ## Testing
 
 Run `./test.sh` to have a proper test suite pass.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Feel free to open pull requests.
 
 ## Setup 
 
-To start developing simply run `npm i` to install dev-dependencies and tools.
+To start developing simply run `npm ci` to install dev-dependencies and tools.
 
 ## Coding Style guide & standard
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,8 +9,17 @@ All notable changes to this project will be documented in this file.
     This is considered a none-breaking change,
     as the CLI use of `npx cyclonedx-node`/`npx cyclonedx-bom`
     is untouched.
+  * Errors are no longer thrown as `String`, but inherited `Error`. (via [#217])  
+    This is considered a none-breaking change,
+    as `Error.toString()` returns the original error message.
+* Fixed
+  * `ExternalReference.type` setter sets value correctly now. (via [#217])  
+    Setter caused an Error or set to `undefined` in the past.
+  * `AttachmentText` sets `encoding` correctly via setter and constructor now. (via [#217])  
+    Set to `undefined` in the past.
 
 [#216]: https://github.com/CycloneDX/cyclonedx-node-module/pull/216
+[#217]: https://github.com/CycloneDX/cyclonedx-node-module/pull/217
 
 ## 3.2.0
 

--- a/bin/make-bom.js
+++ b/bin/make-bom.js
@@ -20,96 +20,98 @@
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 
-const fs = require("fs");
-const process = require('process');
+const fs = require('fs')
+const process = require('process')
 
-const commander = require('commander');
-const DomParser = require('@xmldom/xmldom').DOMParser;
-const xmlFormat = require("prettify-xml");
+const commander = require('commander')
+const DomParser = require('@xmldom/xmldom').DOMParser
+const xmlFormat = require('prettify-xml')
 
-const bomHelpers = require("../index.js");
-const program = require('../package.json');
-const Bom = require('../model/Bom');
-const Component = require('../model/Component');
+const bomHelpers = require('../index.js')
+const program = require('../package.json')
+const Component = require('../model/Component')
 
-const EXIT_SUCCESS = 0;
-const EXIT_INVALID = 1;
-const EXIT_FAILURE = 2;
+const EXIT_SUCCESS = 0
+const EXIT_INVALID = 1
+const EXIT_FAILURE = 2
 
-const xmlOptions = {indent: 4, newline: "\n"};
+const xmlOptions = { indent: 4, newline: '\n' }
 
-const cdx = new commander.Command();
+const cdx = new commander.Command()
 
-let filePath = '.';
+let filePath = '.'
 
 cdx
   .description(program.description)
   .version(program.version, '-v, --version')
   .argument('[path]', 'Path to analyze')
-  .option('-d, --include-dev', "Include devDependencies", false)
-  .option('-l, --include-license-text', "Include full license text", false)
-  .option('-o, --output <output>', "Write BOM to file", "bom.xml")
-  .option('-t, --type <type>', "Project type", "library")
-  .option('-ns, --no-serial-number', "Do not include BOM serial number", true)
+  .option('-d, --include-dev', 'Include devDependencies', false)
+  .option('-l, --include-license-text', 'Include full license text', false)
+  .option('-o, --output <output>', 'Write BOM to file', 'bom.xml')
+  .option('-t, --type <type>', 'Project type', 'library')
+  .option('-ns, --no-serial-number', 'Do not include BOM serial number', true)
   .action((path) => {
-    if (path) filePath = path;
+    if (path) filePath = path
   })
-  .parse(process.argv);
+  .parse(process.argv)
 
-const options = cdx.opts();
+const options = cdx.opts()
 
-let includeSerialNumber = options.serialNumber;
-let includeLicenseText = options.includeLicenseText;
-let output = options.output;
-let componentType = options.type;
+const includeSerialNumber = options.serialNumber
+const includeLicenseText = options.includeLicenseText
+const output = options.output
+const componentType = options.type
 
 if (Component.supportedComponentTypes().indexOf(componentType) === -1) {
-    throw "Unsupported component type. Supported types are " + Component.supportedComponentTypes().toString();
+  throw new RangeError(
+    'Unsupported component type. Supported types are ' +
+    Component.supportedComponentTypes().toString()
+  )
 }
 
 // Options are specific to readinstalled
-let readInstalledOptions = { dev: options.includeDev };
+const readInstalledOptions = { dev: options.includeDev }
 
 /**
  * Creates a Bom object and writes either XML or JSON.
  */
 bomHelpers.createbom(componentType, includeSerialNumber, includeLicenseText, filePath, readInstalledOptions, (createbomError, bom) => {
-    if(!fs.existsSync(filePath)) {
-        console.error("Folder path does not exist");
-        process.exit(EXIT_INVALID);
-    }
+  if (!fs.existsSync(filePath)) {
+    console.error('Folder path does not exist')
+    process.exit(EXIT_INVALID)
+  }
 
-    if(createbomError) {
-        console.debug(createbomError);
-        console.error(
-            "Ooops. Something stupid happened.",
-            "Please file an issue at https://github.com/CycloneDX/cyclonedx-node-module/issues/new"
-        );
-        process.exit(EXIT_FAILURE);
-    }
+  if (createbomError) {
+    console.debug(createbomError)
+    console.error(
+      'Ooops. Something stupid happened.',
+      'Please file an issue at https://github.com/CycloneDX/cyclonedx-node-module/issues/new'
+    )
+    process.exit(EXIT_FAILURE)
+  }
 
-    const writeFileCB = (writeFileError) => {
-        if (!writeFileError) { process.exit(EXIT_SUCCESS) }
-        console.error("Failed to write output file: " + writeFileError.path);
-        process.exit(EXIT_FAILURE);
-    }
+  const writeFileCB = (writeFileError) => {
+    if (!writeFileError) { process.exit(EXIT_SUCCESS) }
+    console.error('Failed to write output file: ' + writeFileError.path)
+    process.exit(EXIT_FAILURE)
+  }
 
-    if (bom.components.length === 0) {
-        console.info(
-            "There are no components in the BOM.",
-            "The project may not contain dependencies or node_modules does not exist.",
-            "Executing `npm install` prior to CycloneDX may solve the issue."
-        );
-    }
+  if (bom.components.length === 0) {
+    console.info(
+      'There are no components in the BOM.',
+      'The project may not contain dependencies or node_modules does not exist.',
+      'Executing `npm install` prior to CycloneDX may solve the issue.'
+    )
+  }
 
-    if (output.endsWith(".xml")) {
-        let doc = new DomParser().parseFromString(bom.toXML());
-        let xmlString = xmlFormat(doc.toString(), xmlOptions);
-        fs.writeFile(output, xmlString, writeFileCB);
-    } else if (output.endsWith(".json")) {
-        fs.writeFile(output, bom.toJSON(), writeFileCB);
-    } else {
-        console.error("Unsupported file extension. Output filename must end with .xml or .json");
-        process.exit(EXIT_INVALID);
-    }
-});
+  if (output.endsWith('.xml')) {
+    const doc = new DomParser().parseFromString(bom.toXML())
+    const xmlString = xmlFormat(doc.toString(), xmlOptions)
+    fs.writeFile(output, xmlString, writeFileCB)
+  } else if (output.endsWith('.json')) {
+    fs.writeFile(output, bom.toJSON(), writeFileCB)
+  } else {
+    console.error('Unsupported file extension. Output filename must end with .xml or .json')
+    process.exit(EXIT_INVALID)
+  }
+})

--- a/index.js
+++ b/index.js
@@ -16,29 +16,32 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) Steve Springett. All Rights Reserved.
  */
-const readInstalled = require('read-installed');
-const filePath = require('path');
-const Bom = require('./model/Bom');
-const fs = require('fs');
 
+const fs = require('fs')
+const filePath = require('path')
+const readInstalled = require('read-installed')
+
+const Bom = require('./model/Bom')
 
 exports.createbom = (componentType, includeSerialNumber, includeLicenseText, path, options, callback) => readInstalled(path, options, (err, pkgInfo) => {
-  let lockfile
-  if (fs.existsSync(filePath.join(path, "package-lock.json"))) {
-    lockfile = JSON.parse(fs.readFileSync(filePath.join(path, "package-lock.json")));
-  }
-    let bom = new Bom(pkgInfo, componentType, includeSerialNumber, includeLicenseText, lockfile);
-    callback(null, bom);
-});
+  if (err) { callback(err, null); return }
 
-exports.mergebom = function mergebom(doc, additionalDoc) {
-    let additionalDocComponents = additionalDoc.getElementsByTagName("component");
-    // appendChild actually removes the element from additionalDocComponents
-    // which is why we use a while loop instead of a for loop
-    while (additionalDocComponents.length > 0) {
-        doc.getElementsByTagName("components")[0].appendChild(
-          additionalDocComponents[0]
-        );
-    }
-    return true;
-};
+  let lockfile
+  if (fs.existsSync(filePath.join(path, 'package-lock.json'))) {
+    lockfile = JSON.parse(fs.readFileSync(filePath.join(path, 'package-lock.json')))
+  }
+  const bom = new Bom(pkgInfo, componentType, includeSerialNumber, includeLicenseText, lockfile)
+  callback(null, bom)
+})
+
+exports.mergebom = function mergebom (doc, additionalDoc) {
+  const additionalDocComponents = additionalDoc.getElementsByTagName('component')
+  // appendChild actually removes the element from additionalDocComponents
+  // which is why we use a while loop instead of a for loop
+  while (additionalDocComponents.length > 0) {
+    doc.getElementsByTagName('components')[0].appendChild(
+      additionalDocComponents[0]
+    )
+  }
+  return true
+}

--- a/model/AttachmentText.js
+++ b/model/AttachmentText.js
@@ -16,56 +16,56 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const CycloneDXObject = require('./CycloneDXObject');
+
+const CycloneDXObject = require('./CycloneDXObject')
 
 class AttachmentText extends CycloneDXObject {
-
-  constructor(contentType, text, encoding) {
-    super();
-    this._contentType = (contentType) ? contentType : undefined;
-    this._text = (text) ? text : undefined;
-    this._encoding = this.validateEncoding(encoding);
+  constructor (contentType, text, encoding) {
+    super()
+    this._contentType = (contentType) || undefined
+    this._text = (text) || undefined
+    this._encoding = this.validateEncoding(encoding)
   }
 
-  validateEncoding(encoding) {
-    if (encoding && encoding !== "base64") {
-      throw "Encoding may either be null or base64";
-    }
+  validateEncoding (encoding) {
+    if (!encoding) { return undefined }
+    if (encoding === 'base64') { return encoding }
+    throw new RangeError('Encoding may either be null or base64')
   }
 
-  get contentType() {
-    return this._contentType;
+  get contentType () {
+    return this._contentType
   }
 
-  set contentType(value) {
-    this._contentType = this.validateType("Content type", value, String);
+  set contentType (value) {
+    this._contentType = this.validateType('Content type', value, String)
   }
 
-  get text() {
-    return this._text;
+  get text () {
+    return this._text
   }
 
-  set text(value) {
-    this._text = this.validateType("Text", value, String);
+  set text (value) {
+    this._text = this.validateType('Text', value, String)
   }
 
-  get encoding() {
-    return this._encoding;
+  get encoding () {
+    return this._encoding
   }
 
-  set encoding(value) {
-    this._encoding = this.validateEncoding(value);
+  set encoding (value) {
+    this._encoding = this.validateEncoding(value)
   }
 
-  toJSON() {
+  toJSON () {
     return {
-      'contentType': this._contentType,
-      'encoding': this._encoding,
-      'content': this._text
+      contentType: this._contentType,
+      encoding: this._encoding,
+      content: this._text
     }
   }
 
-  toXML() {
+  toXML () {
     return {
       '#cdata': this._text,
       '@content-type': this._contentType,
@@ -74,4 +74,4 @@ class AttachmentText extends CycloneDXObject {
   }
 }
 
-module.exports = AttachmentText;
+module.exports = AttachmentText

--- a/model/Bom.js
+++ b/model/Bom.js
@@ -16,197 +16,196 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const builder = require('xmlbuilder');
-const uuid = require('uuid');
-const Component = require('./Component');
-const CycloneDXObject = require('./CycloneDXObject');
-const Metadata = require('./Metadata');
-const Tool = require('./Tool');
-const program = require('../package.json');
+
+const builder = require('xmlbuilder')
+const uuid = require('uuid')
+const Component = require('./Component')
+const CycloneDXObject = require('./CycloneDXObject')
+const Metadata = require('./Metadata')
+const Tool = require('./Tool')
+const program = require('../package.json')
 
 class Bom extends CycloneDXObject {
-
-  constructor(pkg, componentType, includeSerialNumber = true, includeLicenseText = true, lockfile) {
-    super();
-    this._schemaVersion = "1.3";
-    this._includeSerialNumber = includeSerialNumber;
-    this._includeLicenseText = includeLicenseText;
-    this._version = 1;
+  constructor (pkg, componentType, includeSerialNumber = true, includeLicenseText = true, lockfile) {
+    super()
+    this._schemaVersion = '1.3'
+    this._includeSerialNumber = includeSerialNumber
+    this._includeLicenseText = includeLicenseText
+    this._version = 1
     if (includeSerialNumber) {
-      this._serialNumber = 'urn:uuid:' + uuid.v4();
+      this._serialNumber = 'urn:uuid:' + uuid.v4()
     }
     if (pkg) {
-      this._metadata = this.createMetadata(pkg, componentType);
-      this._components = this.listComponents(pkg, lockfile);
+      this._metadata = this.createMetadata(pkg, componentType)
+      this._components = this.listComponents(pkg, lockfile)
     } else {
-      this._components = [];
+      this._components = []
     }
-
   }
 
-  createMetadata(pkg, componentType) {
-    let metadata = new Metadata();
-    metadata.component = new Component(pkg, this.includeLicenseText);
-    metadata.component.type = componentType;
-    let tool = new Tool("CycloneDX", "Node.js module", program.version);
-    metadata.tools.push(tool);
-    return metadata;
+  createMetadata (pkg, componentType) {
+    const metadata = new Metadata()
+    metadata.component = new Component(pkg, this.includeLicenseText)
+    metadata.component.type = componentType
+    const tool = new Tool('CycloneDX', 'Node.js module', program.version)
+    metadata.tools.push(tool)
+    return metadata
   }
 
   /**
    * For all modules in the specified package, creates a list of
    * component objects from each one.
    */
-  listComponents(pkg, lockfile) {
-    let list = {};
-    let isRootPkg = true;
-    this.createComponent(pkg, list, lockfile, isRootPkg);
-    return Object.keys(list).map(k => (list[k]));
+  listComponents (pkg, lockfile) {
+    const list = {}
+    const isRootPkg = true
+    this.createComponent(pkg, list, lockfile, isRootPkg)
+    return Object.keys(list).map(k => (list[k]))
   }
 
   /**
    * Given the specified package, create a CycloneDX component and add it to the list.
    */
-  createComponent(pkg, list, lockfile, isRootPkg = false) {
-    //read-installed with default options marks devDependencies as extraneous
-    //if a package is marked as extraneous, do not include it as a component
-    if(pkg.extraneous) return;
-    if(!isRootPkg) {
-      let component = new Component(pkg, this.includeLicenseText, lockfile);
+  createComponent (pkg, list, lockfile, isRootPkg = false) {
+    // read-installed with default options marks devDependencies as extraneous
+    // if a package is marked as extraneous, do not include it as a component
+    if (pkg.extraneous) return
+    if (!isRootPkg) {
+      const component = new Component(pkg, this.includeLicenseText, lockfile)
       if (component.externalReferences === undefined || component.externalReferences.length === 0) {
-          delete component.externalReferences;
+        delete component.externalReferences
       }
-      if (list[component.purl]) return; //remove cycles
-      list[component.purl] = component;
+      if (list[component.purl]) return // remove cycles
+      list[component.purl] = component
     }
     if (pkg.dependencies) {
       Object.keys(pkg.dependencies)
         .map(x => pkg.dependencies[x])
-        .filter(x => typeof(x) !== 'string') //remove cycles
-        .map(x => this.createComponent(x, list, lockfile));
+        .filter(x => typeof (x) !== 'string') // remove cycles
+        .map(x => this.createComponent(x, list, lockfile))
     }
   }
 
-  addComponent(component) {
-    if (! this._components) this._components = [];
-    this._components.push(component);
+  addComponent (component) {
+    if (!this._components) this._components = []
+    this._components.push(component)
   }
 
-  get includeSerialNumber() {
-    return this._includeSerialNumber;
+  get includeSerialNumber () {
+    return this._includeSerialNumber
   }
 
-  set includeSerialNumber(value) {
-    this._includeSerialNumber = value;
+  set includeSerialNumber (value) {
+    this._includeSerialNumber = value
   }
 
-  get includeLicenseText() {
-    return this._includeLicenseText;
+  get includeLicenseText () {
+    return this._includeLicenseText
   }
 
-  set includeLicenseText(value) {
-    this._includeLicenseText = value;
+  set includeLicenseText (value) {
+    this._includeLicenseText = value
   }
 
-  get metadata() {
-    return this._metadata;
+  get metadata () {
+    return this._metadata
   }
 
-  set metadata(value) {
-    this._metadata = this.validateType("Metadata", value, Metadata);
+  set metadata (value) {
+    this._metadata = this.validateType('Metadata', value, Metadata)
   }
 
-  get components() {
-    return this._components;
+  get components () {
+    return this._components
   }
 
-  set components(value) {
-    this._components = value;
+  set components (value) {
+    this._components = value
   }
 
-  get dependencies() {
-    return this._dependencies;
+  get dependencies () {
+    return this._dependencies
   }
 
-  set dependencies(value) {
-    this._dependencies = value;
+  set dependencies (value) {
+    this._dependencies = value
   }
 
-  addDependency(dependency) {
-    if (! this._dependencies) this._dependencies = [];
-    this._dependencies.push(dependency);
+  addDependency (dependency) {
+    if (!this._dependencies) this._dependencies = []
+    this._dependencies.push(dependency)
   }
 
-  get externalReferences() {
-    return this._externalReferences;
+  get externalReferences () {
+    return this._externalReferences
   }
 
-  set externalReferences(value) {
-    this._externalReferences = value;
+  set externalReferences (value) {
+    this._externalReferences = value
   }
 
-  get version() {
-    return this._version;
+  get version () {
+    return this._version
   }
 
-  set version(value) {
-    this._version = this.validateType("Version", value, Number);
+  set version (value) {
+    this._version = this.validateType('Version', value, Number)
   }
 
-  get schemaVersion() {
-    return this._schemaVersion;
+  get schemaVersion () {
+    return this._schemaVersion
   }
 
-  get serialNumber() {
-    return this._serialNumber;
+  get serialNumber () {
+    return this._serialNumber
   }
 
-  set serialNumber(value) {
-    this._serialNumber = this.validateType("Serial number", value. String);
+  set serialNumber (value) {
+    this._serialNumber = this.validateType('Serial number', value.String)
   }
 
-  toJSON() {
-    let json = {
-      "bomFormat": "CycloneDX",
-      "specVersion": this._schemaVersion,
-      "serialNumber": this._serialNumber,
-      "version": this._version,
-      "metadata": this._metadata,
-      "components": this._components,
-      "dependencies": this._dependencies
-    };
-    return JSON.stringify(json, null, 2);
+  toJSON () {
+    const json = {
+      bomFormat: 'CycloneDX',
+      specVersion: this._schemaVersion,
+      serialNumber: this._serialNumber,
+      version: this._version,
+      metadata: this._metadata,
+      components: this._components,
+      dependencies: this._dependencies
+    }
+    return JSON.stringify(json, null, 2)
   }
 
-  toXML() {
-    let bom = builder.create('bom', { encoding: 'utf-8', separateArrayItems: true })
-      .att('xmlns', 'http://cyclonedx.org/schema/bom/' + this._schemaVersion);
+  toXML () {
+    const bom = builder.create('bom', { encoding: 'utf-8', separateArrayItems: true })
+      .att('xmlns', 'http://cyclonedx.org/schema/bom/' + this._schemaVersion)
     if (this._serialNumber) {
-      bom.att('serialNumber', this._serialNumber);
+      bom.att('serialNumber', this._serialNumber)
     }
-    bom.att('version', this._version);
+    bom.att('version', this._version)
 
     if (this._metadata) {
-      let metadata = bom.ele("metadata");
-      metadata.ele(this._metadata.toXML());
+      const metadata = bom.ele('metadata')
+      metadata.ele(this._metadata.toXML())
     }
 
-    let componentsNode = bom.ele('components');
+    const componentsNode = bom.ele('components')
     if (this._components && this._components.length > 0) {
-      let value = [];
-      for (let component of this._components) {
-        value.push(component.toXML());
+      const value = []
+      for (const component of this._components) {
+        value.push(component.toXML())
       }
-      componentsNode.ele(value);
+      componentsNode.ele(value)
     }
 
     if (this._dependencies && this._dependencies.length > 0) {
-      let dependenciesNode = bom.ele('dependencies');
-      let value = [];
-      for (let dependency of this._dependencies) {
-        value.push(dependency.toXML());
+      const dependenciesNode = bom.ele('dependencies')
+      const value = []
+      for (const dependency of this._dependencies) {
+        value.push(dependency.toXML())
       }
-      dependenciesNode.ele(value);
+      dependenciesNode.ele(value)
     }
 
     return bom.end({
@@ -216,8 +215,8 @@ class Bom extends CycloneDXObject {
       width: 0,
       allowEmpty: false,
       spacebeforeslash: ''
-    });
+    })
   }
 }
 
-module.exports = Bom;
+module.exports = Bom

--- a/model/Component.js
+++ b/model/Component.js
@@ -16,36 +16,35 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const parsePackageJsonName = require('parse-packagejson-name');
-const { PackageURL } = require('packageurl-js');
-const CycloneDXObject = require('./CycloneDXObject');
-const LicenseChoice = require('./LicenseChoice');
-const HashList = require('./HashList');
-const ExternalReferenceList = require('./ExternalReferenceList');
-const OrganizationalEntity = require('./OrganizationalEntity');
-const Swid = require('./Swid');
+
+const parsePackageJsonName = require('parse-packagejson-name')
+const { PackageURL } = require('packageurl-js')
+const CycloneDXObject = require('./CycloneDXObject')
+const LicenseChoice = require('./LicenseChoice')
+const HashList = require('./HashList')
+const ExternalReferenceList = require('./ExternalReferenceList')
+const OrganizationalEntity = require('./OrganizationalEntity')
+const Swid = require('./Swid')
 
 class Component extends CycloneDXObject {
-
-  constructor(pkg, includeLicenseText = true, lockfile) {
-    super();
-    this._type = this.determinePackageType(pkg); // Defaults to library
+  constructor (pkg, includeLicenseText = true, lockfile) {
+    super()
+    this._type = this.determinePackageType(pkg) // Defaults to library
     if (pkg) {
-      let pkgIdentifier = parsePackageJsonName(pkg.name);
-      this._group = (pkgIdentifier.scope) ? pkgIdentifier.scope : undefined;
-      if (this._group) this._group = '@' + this._group;
-      this._name = (pkgIdentifier.fullName) ? pkgIdentifier.fullName : undefined;
-      this._version = (pkg.version) ? pkg.version : undefined;
-      this._description = (pkg.description) ? pkg.description : undefined;
-      this._licenses = new LicenseChoice(pkg, includeLicenseText);
-      this._hashes = new HashList(pkg, lockfile);
-      this._externalReferences = new ExternalReferenceList(pkg);
-      if (this._name && this._version)
-        this._purl = new PackageURL('npm', this._group, this._name, this._version, null, null).toString();
-      this._bomRef = this._purl;
+      const pkgIdentifier = parsePackageJsonName(pkg.name)
+      this._group = (pkgIdentifier.scope) ? pkgIdentifier.scope : undefined
+      if (this._group) this._group = '@' + this._group
+      this._name = (pkgIdentifier.fullName) ? pkgIdentifier.fullName : undefined
+      this._version = (pkg.version) ? pkg.version : undefined
+      this._description = (pkg.description) ? pkg.description : undefined
+      this._licenses = new LicenseChoice(pkg, includeLicenseText)
+      this._hashes = new HashList(pkg, lockfile)
+      this._externalReferences = new ExternalReferenceList(pkg)
+      if (this._name && this._version) { this._purl = new PackageURL('npm', this._group, this._name, this._version, null, null).toString() }
+      this._bomRef = this._purl
     } else {
-      this._hashes = new HashList();
-      this._externalReferences = new ExternalReferenceList();
+      this._hashes = new HashList()
+      this._externalReferences = new ExternalReferenceList()
     }
   }
 
@@ -53,161 +52,161 @@ class Component extends CycloneDXObject {
    * If the author has described the module as a 'framework', the take their
    * word for it, otherwise, identify the module as a 'library'.
    */
-  determinePackageType(pkg) {
-    if (pkg && pkg.hasOwnProperty('keywords')) {
-      for (let keyword of pkg.keywords) {
+  determinePackageType (pkg) {
+    if (pkg && Object.prototype.hasOwnProperty.call(pkg, 'keywords')) {
+      for (const keyword of pkg.keywords) {
         if (keyword.toLowerCase() === 'framework') {
-          return 'framework';
+          return 'framework'
         }
       }
     }
-    return 'library';
+    return 'library'
   }
 
-  static supportedComponentTypes() {
-    return ['application', 'framework', 'library', 'container', 'operating-system', 'device', 'firmware', 'file'];
+  static supportedComponentTypes () {
+    return ['application', 'framework', 'library', 'container', 'operating-system', 'device', 'firmware', 'file']
   }
 
-  get type() {
-    return this._type;
+  get type () {
+    return this._type
   }
 
-  set type(value) {
-    this._type = this.validateChoice("Type", value, Component.supportedComponentTypes());
+  set type (value) {
+    this._type = this.validateChoice('Type', value, Component.supportedComponentTypes())
   }
 
-  get bomRef() {
-    return this._bomRef;
+  get bomRef () {
+    return this._bomRef
   }
 
-  set bomRef(value) {
-    this._bomRef = this.validateType("bom-ref", value, String);
+  set bomRef (value) {
+    this._bomRef = this.validateType('bom-ref', value, String)
   }
 
-  get supplier() {
-    return this._supplier;
+  get supplier () {
+    return this._supplier
   }
 
-  set supplier(value) {
-    this._supplier = this.validateType("Supplier", value, OrganizationalEntity);
+  set supplier (value) {
+    this._supplier = this.validateType('Supplier', value, OrganizationalEntity)
   }
 
-  get author() {
-    return this._author;
+  get author () {
+    return this._author
   }
 
-  set author(value) {
-    this._author = this.validateType("Author", value, String);
+  set author (value) {
+    this._author = this.validateType('Author', value, String)
   }
 
-  get publisher() {
-    return this._publisher;
+  get publisher () {
+    return this._publisher
   }
 
-  set publisher(value) {
-    this._publisher = this.validateType("Publisher", value, String);
+  set publisher (value) {
+    this._publisher = this.validateType('Publisher', value, String)
   }
 
-  get group() {
-    return this._group;
+  get group () {
+    return this._group
   }
 
-  set group(value) {
-    this._group = this.validateType("Group", value, String);
+  set group (value) {
+    this._group = this.validateType('Group', value, String)
   }
 
-  get name() {
-    return this._name;
+  get name () {
+    return this._name
   }
 
-  set name(value) {
-    this._name = this.validateType("Name", value, String);
+  set name (value) {
+    this._name = this.validateType('Name', value, String)
   }
 
-  get version() {
-    return this._version;
+  get version () {
+    return this._version
   }
 
-  set version(value) {
-    this._version = this.validateType("Version", value, String);
+  set version (value) {
+    this._version = this.validateType('Version', value, String)
   }
 
-  get description() {
-    return this._description;
+  get description () {
+    return this._description
   }
 
-  set description(value) {
-    this._description = this.validateType("Description", value, String);
+  set description (value) {
+    this._description = this.validateType('Description', value, String)
   }
 
-  get scope() {
-    return this._scope;
+  get scope () {
+    return this._scope
   }
 
-  set scope(value) {
-    const validChoices = ['required', 'optional', 'excluded'];
-    this._scope = this.validateChoice("Scope", value, validChoices)
+  set scope (value) {
+    const validChoices = ['required', 'optional', 'excluded']
+    this._scope = this.validateChoice('Scope', value, validChoices)
   }
 
-  get hashes() {
-    return this._hashes;
+  get hashes () {
+    return this._hashes
   }
 
-  set hashes(value) {
-    this._hashes = this.validateType("Hashes", value, HashList);
+  set hashes (value) {
+    this._hashes = this.validateType('Hashes', value, HashList)
   }
 
-  get licenses() {
-    return this._licenses;
+  get licenses () {
+    return this._licenses
   }
 
-  set licenses(value) {
-    this._licenses = this.validateType("Licenses", value, LicenseChoice);
+  set licenses (value) {
+    this._licenses = this.validateType('Licenses', value, LicenseChoice)
   }
 
-  get copyright() {
-    return this._copyright;
+  get copyright () {
+    return this._copyright
   }
 
-  set copyright(value) {
-    this._copyright = this.validateType("Copyright", value, String);
+  set copyright (value) {
+    this._copyright = this.validateType('Copyright', value, String)
   }
 
-  get cpe() {
-    return this._cpe;
+  get cpe () {
+    return this._cpe
   }
 
-  set cpe(value) {
-    this._cpe = this.validateType("CPE", value, String);
+  set cpe (value) {
+    this._cpe = this.validateType('CPE', value, String)
   }
 
-  get purl() {
-    return this._purl;
+  get purl () {
+    return this._purl
   }
 
-  set purl(value) {
-    this._purl = this.validateType("PURL", value, String);
+  set purl (value) {
+    this._purl = this.validateType('PURL', value, String)
   }
 
-  get swid() {
-    return this._swid;
+  get swid () {
+    return this._swid
   }
 
-  set swid(value) {
-    this._swid = this.validateType("SWID", value, Swid);
+  set swid (value) {
+    this._swid = this.validateType('SWID', value, Swid)
   }
 
-  get externalReferences() {
-    return this._externalReferences;
+  get externalReferences () {
+    return this._externalReferences
   }
 
-  set externalReferences(value) {
-    this._externalReferences = value;
+  set externalReferences (value) {
+    this._externalReferences = value
   }
 
-  toJSON() {
+  toJSON () {
     return {
-      'type': this._type,
+      type: this._type,
       'bom-ref': this._bomRef,
       supplier: this._supplier ? this._supplier.toJSON() : undefined,
       author: this._author,
@@ -223,13 +222,13 @@ class Component extends CycloneDXObject {
       cpe: this._cpe,
       purl: this._purl,
       swid: this._swid ? this.swid.toJSON() : undefined,
-      externalReferences: (this._externalReferences && this._externalReferences.externalReferences && this._externalReferences.externalReferences.length > 0) ? this._externalReferences.toJSON() : undefined,
-    };
+      externalReferences: (this._externalReferences && this._externalReferences.externalReferences && this._externalReferences.externalReferences.length > 0) ? this._externalReferences.toJSON() : undefined
+    }
   }
 
-  toXML() {
+  toXML () {
     return {
-      'component': {
+      component: {
         '@type': this._type,
         '@bom-ref': this._bomRef,
         supplier: this._supplier ? this._supplier.toXML() : undefined,
@@ -238,7 +237,7 @@ class Component extends CycloneDXObject {
         group: this._group,
         name: this._name,
         version: this._version,
-        description: (this._description) ? {'#cdata': this._description} : undefined,
+        description: (this._description) ? { '#cdata': this._description } : undefined,
         scope: this._scope,
         hashes: (this._hashes && this.hashes.hashes && this.hashes.hashes.length > 0) ? this._hashes.toXML() : undefined,
         licenses: (this._licenses) ? this._licenses.toXML() : undefined,
@@ -246,10 +245,10 @@ class Component extends CycloneDXObject {
         cpe: this._cpe,
         purl: this._purl,
         swid: this._swid ? this.swid.toXML() : undefined,
-        externalReferences: (this._externalReferences && this._externalReferences.externalReferences && this._externalReferences.externalReferences.length > 0) ? this._externalReferences.toXML() : undefined,
+        externalReferences: (this._externalReferences && this._externalReferences.externalReferences && this._externalReferences.externalReferences.length > 0) ? this._externalReferences.toXML() : undefined
       }
-    };
+    }
   }
 }
 
-module.exports = Component;
+module.exports = Component

--- a/model/CycloneDXObject.js
+++ b/model/CycloneDXObject.js
@@ -16,56 +16,47 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const defaultSpecVersion = "1.3";
 
 class CycloneDXObject {
-
-  constructor() {
-  }
-
-  validateType(name, value, expectedType, required = false) {
-    if (!value && required) {
-      throw name + " is required";
+  validateType (name, value, expectedType, required = false) {
+    if (!value) {
+      if (required) { throw new ReferenceError(name + ' is required') }
+      return undefined
     }
-    if (value) {
-      if (expectedType === String) {
-        if (typeof value === 'string' || value instanceof expectedType) {
-          return value;
-        } else {
-          throw name + " value must be a string";
-        }
-      } else if (expectedType === Number) {
-        if (typeof value === 'number' || value instanceof expectedType) {
-          return value;
-        } else {
-          throw name + " value must be a number";
-        }
-      } else if (expectedType === Boolean) {
-        if (typeof value === 'boolean' || value instanceof expectedType) {
-          return value;
-        } else {
-          throw name + " value must be a number";
-        }
-      } else {
-        if (value instanceof expectedType) {
-          return value;
-        } else {
-          throw name + " value must be an instance of " + expectedType;
-        }
+
+    if (expectedType === String) {
+      if (typeof value === 'string' || value instanceof expectedType) {
+        return value
       }
-    } else {
-      return undefined;
+      throw new TypeError(name + ' value must be a string')
     }
+
+    if (expectedType === Number) {
+      if (typeof value === 'number' || value instanceof expectedType) {
+        return value
+      }
+      throw new TypeError(name + ' value must be a number')
+    }
+
+    if (expectedType === Boolean) {
+      if (typeof value === 'boolean' || value instanceof expectedType) {
+        return value
+      }
+      throw new TypeError(name + ' value must be a boolean')
+    }
+
+    if (value instanceof expectedType) {
+      return value
+    }
+    throw TypeError(name + ' value must be an instance of ' + expectedType)
   }
 
-  validateChoice(name, value, validChoices = []) {
+  validateChoice (name, value, validChoices = []) {
     if (validChoices.indexOf(value) === -1) {
-      throw "Unsupported " + name + ". Valid choices are " + validChoices.toString();
-    } else {
-      return value;
+      throw new RangeError('Unsupported ' + name + '. Valid choices are ' + validChoices.toString())
     }
+    return value
   }
-
 }
 
-module.exports = CycloneDXObject;
+module.exports = CycloneDXObject

--- a/model/Dependency.js
+++ b/model/Dependency.js
@@ -16,66 +16,66 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const CycloneDXObject = require('./CycloneDXObject');
+
+const CycloneDXObject = require('./CycloneDXObject')
 
 class Dependency extends CycloneDXObject {
+  constructor (ref, dependencies) {
+    super()
+    this._ref = ref
+    this._dependencies = dependencies
+  }
 
-    constructor(ref, dependencies) {
-        super();
-        this._ref = ref;
-        this._dependencies = dependencies;
-    }
+  get ref () {
+    return this._ref
+  }
 
-    get ref() {
-        return this._ref;
-    }
+  set ref (value) {
+    this._ref = value
+  }
 
-    set ref(value) {
-        this._ref = value;
-    }
+  get dependencies () {
+    return this._dependencies
+  }
 
-    get dependencies() {
-        return this._dependencies;
-    }
+  set dependencies (value) {
+    this._dependencies = value
+  }
 
-    set dependencies(value) {
-        this._dependencies = value;
-    }
+  addDependency (dependency) {
+    if (!this._dependencies) this._dependencies = []
+    this._dependencies.push(dependency)
+  }
 
-    addDependency(dependency) {
-        if (! this._dependencies) this._dependencies = [];
-        this._dependencies.push(dependency);
+  toJSON () {
+    let dependencyArray
+    if (this._dependencies && this._dependencies.length > 0) {
+      dependencyArray = []
+      for (const d of this._dependencies) {
+        dependencyArray.push(d.ref)
+      }
     }
+    return {
+      ref: this._ref,
+      dependsOn: dependencyArray
+    }
+  }
 
-    toJSON() {
-        let dependencyArray = undefined;
-        if (this._dependencies && this._dependencies.length > 0) {
-            dependencyArray = [];
-            for (let d of this._dependencies) {
-                dependencyArray.push(d.ref);
-            }
-        }
-        return {
-            'ref': this._ref,
-            'dependsOn': dependencyArray
-        };
+  toXML () {
+    let dependencyArray
+    if (this._dependencies && this._dependencies.length > 0) {
+      dependencyArray = []
+      for (const d of this._dependencies) {
+        dependencyArray.push({ dependency: { '@ref': d.ref } })
+      }
     }
-
-    toXML() {
-        let dependencyArray = undefined;
-        if (this._dependencies && this._dependencies.length > 0) {
-            dependencyArray = [];
-            for (let d of this._dependencies) {
-                dependencyArray.push({'dependency': {'@ref': d.ref}});
-            }
-        }
-        return {
-            'dependency': {
-                '@ref': this.ref,
-                '#text': dependencyArray
-            }
-        };
+    return {
+      dependency: {
+        '@ref': this.ref,
+        '#text': dependencyArray
+      }
     }
+  }
 }
 
-module.exports = Dependency;
+module.exports = Dependency

--- a/model/ExternalReference.js
+++ b/model/ExternalReference.js
@@ -16,53 +16,53 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const CycloneDXObject = require('./CycloneDXObject');
+
+const CycloneDXObject = require('./CycloneDXObject')
 
 class ExternalReference extends CycloneDXObject {
-
-  constructor(type, url, comment) {
-    super();
-    this._type = this.validateChoice("Reference type", type, this.validChoices());
-    this._url = url;
-    this._comment = comment;
+  constructor (type, url, comment) {
+    super()
+    this._type = this.validateChoice('Reference type', type, this.validChoices())
+    this._url = url
+    this._comment = comment
   }
 
-  validChoices() {
-    return ["vcs", "issue-tracker", "website", "advisories", "bom", "mailing-list", "social", "chat",
-      "documentation", "support", "distribution", "license", "build-meta", "build-system", "other"];
+  validChoices () {
+    return ['vcs', 'issue-tracker', 'website', 'advisories', 'bom', 'mailing-list', 'social', 'chat',
+      'documentation', 'support', 'distribution', 'license', 'build-meta', 'build-system', 'other']
   }
 
-  get url() {
-    return this._url;
+  get url () {
+    return this._url
   }
 
-  set url(value) {
-    this._url = this.validateType("URL", value, String);
+  set url (value) {
+    this._url = this.validateType('URL', value, String)
   }
 
-  get type() {
-    return this._type;
+  get type () {
+    return this._type
   }
 
-  set type(value) {
-    this._type = this.validateChoice("Reference type", type, this.validChoices());
+  set type (value) {
+    this._type = this.validateChoice('Reference type', value, this.validChoices())
   }
 
-  get comment() {
-    return this._comment;
+  get comment () {
+    return this._comment
   }
 
-  set comment(value) {
-    this._comment = this.validateType("Comment", value, String);
+  set comment (value) {
+    this._comment = this.validateType('Comment', value, String)
   }
 
-  toJSON() {
-    return { 'type': this._type, 'url': this._url} ;
+  toJSON () {
+    return { type: this._type, url: this._url }
   }
 
-  toXML() {
-    return { reference: { '@type': this._type, 'url': this._url} };
+  toXML () {
+    return { reference: { '@type': this._type, url: this._url } }
   }
 }
 
-module.exports = ExternalReference;
+module.exports = ExternalReference

--- a/model/ExternalReferenceList.js
+++ b/model/ExternalReferenceList.js
@@ -16,56 +16,55 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const ExternalReference = require('./ExternalReference');
+
+const ExternalReference = require('./ExternalReference')
 
 class ExternalReferenceList {
-
-  constructor(pkg) {
-    this._externalReferences = [];
+  constructor (pkg) {
+    this._externalReferences = []
     if (pkg) {
-      this.processExternalReferences(pkg);
+      this.processExternalReferences(pkg)
     }
   }
 
-  get externalReferences() {
-    return this._externalReferences;
+  get externalReferences () {
+    return this._externalReferences
   }
 
-  set externalReferences(value) {
+  set externalReferences (value) {
     if (!Array.isArray(value)) {
-      throw "ExternalReferencesList value must be an array of ExternalReference objects";
-    } else {
-      this._externalReferences = value;
+      throw new TypeError('ExternalReferencesList value must be an array of ExternalReference objects')
     }
+    this._externalReferences = value
   }
 
-  processExternalReferences(pkg) {
+  processExternalReferences (pkg) {
     if (pkg.homepage) {
-      this._externalReferences.push(new ExternalReference("website", pkg.homepage));
+      this._externalReferences.push(new ExternalReference('website', pkg.homepage))
     }
     if (pkg.bugs && pkg.bugs.url) {
-      this._externalReferences.push(new ExternalReference("issue-tracker", pkg.bugs.url));
+      this._externalReferences.push(new ExternalReference('issue-tracker', pkg.bugs.url))
     }
     if (pkg.repository && pkg.repository.url) {
-      this._externalReferences.push(new ExternalReference("vcs", pkg.repository.url));
+      this._externalReferences.push(new ExternalReference('vcs', pkg.repository.url))
     }
   }
 
-  toJSON() {
-    let value = [];
-    for (let externalReference of this._externalReferences) {
-      value.push(externalReference.toJSON());
+  toJSON () {
+    const value = []
+    for (const externalReference of this._externalReferences) {
+      value.push(externalReference.toJSON())
     }
-    return value;
+    return value
   }
 
-  toXML() {
-    let value = [];
-    for (let externalReference of this._externalReferences) {
-      value.push(externalReference.toXML());
+  toXML () {
+    const value = []
+    for (const externalReference of this._externalReferences) {
+      value.push(externalReference.toXML())
     }
-    return value;
+    return value
   }
 }
 
-module.exports = ExternalReferenceList;
+module.exports = ExternalReferenceList

--- a/model/Hash.js
+++ b/model/Hash.js
@@ -16,44 +16,44 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const CycloneDXObject = require('./CycloneDXObject');
+
+const CycloneDXObject = require('./CycloneDXObject')
 
 class Hash extends CycloneDXObject {
-
-  constructor(algorithm, value) {
-    super();
-    this._algorithm = this.validateChoice("Algorithm", algorithm, this.validAlgorithms());
-    this._value = value;
+  constructor (algorithm, value) {
+    super()
+    this._algorithm = this.validateChoice('Algorithm', algorithm, this.validAlgorithms())
+    this._value = value
   }
 
-  validAlgorithms() {
-    return ["MD5", "SHA-1", "SHA-256", "SHA-384", "SHA-512", "SHA3-256", "SHA3-384",
-      "SHA3-512", "BLAKE2b-256", "BLAKE2b-384", "BLAKE2b-512", "BLAKE3"];
+  validAlgorithms () {
+    return ['MD5', 'SHA-1', 'SHA-256', 'SHA-384', 'SHA-512', 'SHA3-256', 'SHA3-384',
+      'SHA3-512', 'BLAKE2b-256', 'BLAKE2b-384', 'BLAKE2b-512', 'BLAKE3']
   }
 
-  get algorithm() {
-    return this._algorithm;
+  get algorithm () {
+    return this._algorithm
   }
 
-  set algorithm(value) {
-    this._algorithm = this.validateChoice("Algorithm", value, this.validAlgorithms());
+  set algorithm (value) {
+    this._algorithm = this.validateChoice('Algorithm', value, this.validAlgorithms())
   }
 
-  get value() {
-    return this._value;
+  get value () {
+    return this._value
   }
 
-  set value(value) {
-    this._value = this.validateType("Hash value", value, String);
+  set value (value) {
+    this._value = this.validateType('Hash value', value, String)
   }
 
-  toJSON() {
-    return { 'alg': this._algorithm, 'content': this._value};
+  toJSON () {
+    return { alg: this._algorithm, content: this._value }
   }
 
-  toXML() {
-    return { hash: { '@alg': this._algorithm, '#text': this._value} };
+  toXML () {
+    return { hash: { '@alg': this._algorithm, '#text': this._value } }
   }
 }
 
-module.exports = Hash;
+module.exports = Hash

--- a/model/HashList.js
+++ b/model/HashList.js
@@ -16,81 +16,80 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const ssri = require('ssri');
-const Hash = require('./Hash');
+
+const ssri = require('ssri')
+const Hash = require('./Hash')
 
 class HashList {
-
-  constructor(pkg, lockfile) {
-    this._hashes = [];
+  constructor (pkg, lockfile) {
+    this._hashes = []
     if (pkg) {
-      this.processHashes(pkg,lockfile);
+      this.processHashes(pkg, lockfile)
     }
   }
 
-  get hashes() {
-    return this._hashes;
+  get hashes () {
+    return this._hashes
   }
 
-  set hashes(value) {
+  set hashes (value) {
     if (!Array.isArray(value)) {
-      throw "HashList value must be an array of Hash objects";
-    } else {
-      this._hashes = value;
+      throw new TypeError('HashList value must be an array of Hash objects')
     }
+    this._hashes = value
   }
 
-  processHashes(pkg, lockfile) {
+  processHashes (pkg, lockfile) {
     // Default to checking the package-lock.json first and checking the node
     // module package.json as a backup.
     if (lockfile) {
       if (lockfile.dependencies && lockfile.dependencies[pkg.name] && lockfile.dependencies[pkg.name].integrity) {
-        this.formatHash(ssri.parse(lockfile.dependencies[pkg.name].integrity));
+        this.formatHash(ssri.parse(lockfile.dependencies[pkg.name].integrity))
       }
     } else if (pkg._shasum) {
-      this._hashes.push(new Hash("SHA-1", pkg._shasum));
+      this._hashes.push(new Hash('SHA-1', pkg._shasum))
     } else if (pkg._integrity) {
-      this.formatHash(ssri.parse(pkg._integrity));
+      this.formatHash(ssri.parse(pkg._integrity))
     }
   }
 
-  formatHash(integrity){
-        // Components may have multiple hashes with various lengths. Check each one
-        // that is supported by the CycloneDX specification.
-        if (integrity.hasOwnProperty('sha512')) {
-          this._hashes.push(this.createHash('SHA-512', integrity.sha512[0].digest));
-        }
-        if (integrity.hasOwnProperty('sha384')) {
-          this._hashes.push(this.createHash('SHA-384', integrity.sha384[0].digest));
-        }
-        if (integrity.hasOwnProperty('sha256')) {
-          this._hashes.push(this.createHash('SHA-256', integrity.sha256[0].digest));
-        }
-        if (integrity.hasOwnProperty('sha1')) {
-          this._hashes.push(this.createHash('SHA-1', integrity.sha1[0].digest));
-        }
-  }
-
-  createHash(algorithm, digest) {
-    let hash = Buffer.from(digest, 'base64').toString('hex');
-    return new Hash(algorithm, hash);
-  }
-
-  toJSON() {
-    let value = [];
-    for (let hash of this._hashes) {
-      value.push(hash.toJSON());
+  formatHash (integrity) {
+    // Components may have multiple hashes with various lengths. Check each one
+    // that is supported by the CycloneDX specification.
+    if (Object.prototype.hasOwnProperty.call(integrity, 'sha512')) {
+      this._hashes.push(this.createHash('SHA-512', integrity.sha512[0].digest))
     }
-    return value;
+    if (Object.prototype.hasOwnProperty.call(integrity, 'sha384')) {
+      this._hashes.push(this.createHash('SHA-384', integrity.sha384[0].digest))
+    }
+    if (Object.prototype.hasOwnProperty.call(integrity, 'sha256')) {
+      this._hashes.push(this.createHash('SHA-256', integrity.sha256[0].digest))
+    }
+    if (Object.prototype.hasOwnProperty.call(integrity, 'sha1')) {
+      this._hashes.push(this.createHash('SHA-1', integrity.sha1[0].digest))
+    }
   }
 
-  toXML() {
-    let value = [];
-    for (let hash of this._hashes) {
-      value.push(hash.toXML());
+  createHash (algorithm, digest) {
+    const hash = Buffer.from(digest, 'base64').toString('hex')
+    return new Hash(algorithm, hash)
+  }
+
+  toJSON () {
+    const value = []
+    for (const hash of this._hashes) {
+      value.push(hash.toJSON())
     }
-    return value;
+    return value
+  }
+
+  toXML () {
+    const value = []
+    for (const hash of this._hashes) {
+      value.push(hash.toXML())
+    }
+    return value
   }
 }
 
-module.exports = HashList;
+module.exports = HashList

--- a/model/License.js
+++ b/model/License.js
@@ -16,50 +16,46 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const AttachmentText = require('./AttachmentText');
-const CycloneDXObject = require('./CycloneDXObject');
 
-class License extends  CycloneDXObject {
+const AttachmentText = require('./AttachmentText')
+const CycloneDXObject = require('./CycloneDXObject')
 
-  constructor() {
-    super();
+class License extends CycloneDXObject {
+  get id () {
+    return this._id
   }
 
-  get id() {
-    return this._id;
+  set id (value) {
+    this._name = undefined
+    this._id = this.validateType('SPDX License ID', value, String)
   }
 
-  set id(value) {
-    this._name = undefined;
-    this._id = this.validateType("SPDX License ID", value, String);
+  get name () {
+    return this._name
   }
 
-  get name() {
-    return this._name;
+  set name (value) {
+    this._id = undefined
+    this._name = this.validateType('License name', value, String)
   }
 
-  set name(value) {
-    this._id = undefined;
-    this._name = this.validateType("License name", value, String);
+  get url () {
+    return this._url
   }
 
-  get url() {
-    return this._url;
+  set url (value) {
+    this._url = this.validateType('URL', value, String)
   }
 
-  set url(value) {
-    this._url = this.validateType("URL", value, String);
+  get attachmentText () {
+    return this._attachmentText
   }
 
-  get attachmentText() {
-    return this._attachmentText;
+  set attachmentText (value) {
+    this._attachmentText = this.validateType('Attachment text', value, AttachmentText)
   }
 
-  set attachmentText(value) {
-    this._attachmentText = this.validateType("Attachment text", value, AttachmentText);
-  }
-
-  toJSON() {
+  toJSON () {
     return {
       license: {
         id: this._id,
@@ -70,7 +66,7 @@ class License extends  CycloneDXObject {
     }
   }
 
-  toXML() {
+  toXML () {
     return {
       license: {
         id: this._id,
@@ -78,8 +74,8 @@ class License extends  CycloneDXObject {
         text: (this._attachmentText) ? this._attachmentText.toXML() : null,
         url: this._url
       }
-    };
+    }
   }
 }
 
-module.exports = License;
+module.exports = License

--- a/model/Metadata.js
+++ b/model/Metadata.js
@@ -16,111 +16,109 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const Component = require('./Component');
-const CycloneDXObject = require('./CycloneDXObject');
-const OrganizationalEntity = require('./OrganizationalEntity');
+
+const Component = require('./Component')
+const CycloneDXObject = require('./CycloneDXObject')
+const OrganizationalEntity = require('./OrganizationalEntity')
 
 class Metadata extends CycloneDXObject {
-
-  constructor() {
-    super();
-    this._timestamp = new Date();
-    this._tools = [];
-    this._authors = [];
+  constructor () {
+    super()
+    this._timestamp = new Date()
+    this._tools = []
+    this._authors = []
   }
 
-  get timestamp() {
-    return this._timestamp;
+  get timestamp () {
+    return this._timestamp
   }
 
-  set timestamp(value) {
-    this._timestamp = this.validateType("Timestamp", value, Date);
+  set timestamp (value) {
+    this._timestamp = this.validateType('Timestamp', value, Date)
   }
 
-  get tools() {
-    return this._tools;
+  get tools () {
+    return this._tools
   }
 
-  set tools(value) {
+  set tools (value) {
     if (!Array.isArray(value)) {
-      throw "Tools value must be an array of Tool objects";
-    } else {
-      this._tools = value;
+      throw new TypeError('Tools value must be an array of Tool objects')
     }
+    this._tools = value
   }
 
-  get authors() {
-    return this._authors;
+  get authors () {
+    return this._authors
   }
 
-  set authors(value) {
+  set authors (value) {
     if (!Array.isArray(value)) {
-      throw "Authors value must be an array of OrganizationalContact objects";
-    } else {
-      for (const author of value) {
-        author.objectName = "author";
-      }
-      this._authors = value;
+      throw new TypeError('Authors value must be an array of OrganizationalContact objects')
     }
+    for (const author of value) {
+      author.objectName = 'author'
+    }
+    this._authors = value
   }
 
-  get component() {
-    return this._component;
+  get component () {
+    return this._component
   }
 
-  set component(value) {
-    this._component = this.validateType("Component", value, Component);
+  set component (value) {
+    this._component = this.validateType('Component', value, Component)
   }
 
-  get manufacture() {
-    return this._manufacture;
+  get manufacture () {
+    return this._manufacture
   }
 
-  set manufacture(value) {
-    this._manufacture = this.validateType("Manufacture", value, OrganizationalEntity);
+  set manufacture (value) {
+    this._manufacture = this.validateType('Manufacture', value, OrganizationalEntity)
   }
 
-  get supplier() {
-    return this._supplier;
+  get supplier () {
+    return this._supplier
   }
 
-  set supplier(value) {
-    this._supplier = this.validateType("Supplier", value, OrganizationalEntity);
+  set supplier (value) {
+    this._supplier = this.validateType('Supplier', value, OrganizationalEntity)
   }
 
-  processArray(array, format) {
-    let value = [];
+  processArray (array, format) {
+    const value = []
     for (const object of array) {
       if (format === 'XML') {
-        value.push(object.toXML());
+        value.push(object.toXML())
       } else if (format === 'JSON') {
-        value.push(object.toJSON());
+        value.push(object.toJSON())
       }
     }
-    return value;
+    return value
   }
 
-  toJSON() {
+  toJSON () {
     return {
       timestamp: (this._timestamp) ? this._timestamp.toISOString() : undefined,
-      tools: (this._tools && this._tools.length > 0) ? this.processArray(this._tools, "JSON") : undefined,
-      authors: (this._authors && this._authors.length > 0) ? this.processArray(this._authors, "JSON") : undefined,
+      tools: (this._tools && this._tools.length > 0) ? this.processArray(this._tools, 'JSON') : undefined,
+      authors: (this._authors && this._authors.length > 0) ? this.processArray(this._authors, 'JSON') : undefined,
       component: (this._component) ? this._component.toJSON() : undefined,
       manufacture: (this._manufacture) ? this._manufacture.toJSON() : undefined,
       supplier: (this._supplier) ? this._supplier.toJSON() : undefined
-    };
+    }
   }
 
-  toXML() {
+  toXML () {
     return {
       timestamp: (this._timestamp) ? this._timestamp.toISOString() : undefined,
-      tools: (this._tools && this._tools.length > 0) ? this.processArray(this._tools, "XML") : undefined,
-      authors: (this._authors && this._authors.length > 0) ? this.processArray(this._authors, "XML") : undefined,
+      tools: (this._tools && this._tools.length > 0) ? this.processArray(this._tools, 'XML') : undefined,
+      authors: (this._authors && this._authors.length > 0) ? this.processArray(this._authors, 'XML') : undefined,
       component: (this._component) ? this._component.toXML().component : undefined,
       manufacture: (this._manufacture) ? this._manufacture.toXML() : undefined,
       supplier: (this._supplier) ? this._supplier.toXML() : undefined
-    };
+    }
   }
 }
 
-module.exports = Metadata;
+module.exports = Metadata

--- a/model/OrganizationalContact.js
+++ b/model/OrganizationalContact.js
@@ -16,51 +16,51 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const CycloneDXObject = require('./CycloneDXObject');
 
-class OrganizationalContact extends  CycloneDXObject {
+const CycloneDXObject = require('./CycloneDXObject')
 
-  constructor(name, email, phone, objectName) {
-    super();
-    this._name = this.validateType("Name", name, String);
-    this._email = this.validateType("Email", email, String);
-    this._phone = this.validateType("Phone", phone, String);
-    this._objectName = objectName;
+class OrganizationalContact extends CycloneDXObject {
+  constructor (name, email, phone, objectName) {
+    super()
+    this._name = this.validateType('Name', name, String)
+    this._email = this.validateType('Email', email, String)
+    this._phone = this.validateType('Phone', phone, String)
+    this._objectName = objectName
   }
 
-  get name() {
-    return this._name;
+  get name () {
+    return this._name
   }
 
-  set name(value) {
-    this._name = this.validateType("Name", value, String);
+  set name (value) {
+    this._name = this.validateType('Name', value, String)
   }
 
-  get email() {
-    return this._email;
+  get email () {
+    return this._email
   }
 
-  set email(value) {
-    this._email = this.validateType("Email", value, String);
+  set email (value) {
+    this._email = this.validateType('Email', value, String)
   }
 
-  get phone() {
-    return this._phone;
+  get phone () {
+    return this._phone
   }
 
-  set phone(value) {
-    this._phone = this.validateType("Phone", value, String);
+  set phone (value) {
+    this._phone = this.validateType('Phone', value, String)
   }
 
-  get objectName() {
-    return this._objectName;
+  get objectName () {
+    return this._objectName
   }
 
-  set objectName(value) {
-    this._objectName = this.validateType("Objectname", value, String);
+  set objectName (value) {
+    this._objectName = this.validateType('Objectname', value, String)
   }
 
-  toJSON() {
+  toJSON () {
     return {
       name: this._name,
       email: this._email,
@@ -68,15 +68,15 @@ class OrganizationalContact extends  CycloneDXObject {
     }
   }
 
-  toXML() {
-    let data = {};
+  toXML () {
+    const data = {}
     if (this._objectName) {
       data[this._objectName] = {
         name: this._name,
         email: this._email,
         phone: this._phone
-      };
-      return data;
+      }
+      return data
     } else {
       return {
         name: this._name,
@@ -87,4 +87,4 @@ class OrganizationalContact extends  CycloneDXObject {
   }
 }
 
-module.exports = OrganizationalContact;
+module.exports = OrganizationalContact

--- a/model/OrganizationalEntity.js
+++ b/model/OrganizationalEntity.js
@@ -16,44 +16,44 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const CycloneDXObject = require('./CycloneDXObject');
-const OrganizationalContact = require('./OrganizationalContact');
+
+const CycloneDXObject = require('./CycloneDXObject')
+const OrganizationalContact = require('./OrganizationalContact')
 
 class OrganizationalEntity extends CycloneDXObject {
-
-  constructor(name, url, contact, objectName) {
-    super();
-    this._name = this.validateType("Name", name, String);
-    this._url = this.validateType("URL", url, String);
-    this._contact = this.validateType("Contact", contact, OrganizationalContact);
-    this._objectName = objectName;
+  constructor (name, url, contact, objectName) {
+    super()
+    this._name = this.validateType('Name', name, String)
+    this._url = this.validateType('URL', url, String)
+    this._contact = this.validateType('Contact', contact, OrganizationalContact)
+    this._objectName = objectName
   }
 
-  get name() {
-    return this._name;
+  get name () {
+    return this._name
   }
 
-  set name(value) {
-    this._name = this.validateType("Name", value, String);
+  set name (value) {
+    this._name = this.validateType('Name', value, String)
   }
 
-  get url() {
-    return this._url;
+  get url () {
+    return this._url
   }
 
-  set url(value) {
-    this._url = this.validateType("URL", value, String);
+  set url (value) {
+    this._url = this.validateType('URL', value, String)
   }
 
-  get contact() {
-    return this._contact;
+  get contact () {
+    return this._contact
   }
 
-  set contact(value) {
-    this._contact = this.validateType("Contact", value, OrganizationalContact);
+  set contact (value) {
+    this._contact = this.validateType('Contact', value, OrganizationalContact)
   }
 
-  toJSON() {
+  toJSON () {
     return {
       name: this._name,
       url: [this._url],
@@ -61,15 +61,15 @@ class OrganizationalEntity extends CycloneDXObject {
     }
   }
 
-  toXML() {
-    let data = {};
+  toXML () {
+    const data = {}
     if (this._objectName) {
       data[this._objectName] = {
         name: this._name,
         url: this._url,
         contact: (this._contact) ? this._contact.toXML() : undefined
-      };
-      return data;
+      }
+      return data
     } else {
       return {
         name: this._name,
@@ -80,4 +80,4 @@ class OrganizationalEntity extends CycloneDXObject {
   }
 }
 
-module.exports = OrganizationalEntity;
+module.exports = OrganizationalEntity

--- a/model/Swid.js
+++ b/model/Swid.js
@@ -16,11 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const AttachmentText = require('./AttachmentText');
-const CycloneDXObject = require('./CycloneDXObject');
+
+const AttachmentText = require('./AttachmentText')
+const CycloneDXObject = require('./CycloneDXObject')
 
 class Swid extends CycloneDXObject {
-
   /**
    * @param tagId Maps to the tagId of a SoftwareIdentity. (REQUIRED)
    * @param name Maps to the name of a SoftwareIdentity. (OPTIONAL)
@@ -28,44 +28,44 @@ class Swid extends CycloneDXObject {
    * @param tagVersion Maps to the tagVersion of a SoftwareIdentity. (OPTIONAL)
    * @param patch Maps to the patch of a SoftwareIdentity. (OPTIONAL)
    */
-  constructor(tagId, name, version, tagVersion, patch) {
-    super();
-    this._tagId = this.validateType("SWID tagId", tagId, String, true);
-    this._name = this.validateType("Name", name, String);
-    this._version = this.validateType("Version", version, String);
-    this._tagVersion = this.validateType("Tag version", tagVersion, Number);
-    this._patch = this.validateType("Patch", patch, Boolean);
+  constructor (tagId, name, version, tagVersion, patch) {
+    super()
+    this._tagId = this.validateType('SWID tagId', tagId, String, true)
+    this._name = this.validateType('Name', name, String)
+    this._version = this.validateType('Version', version, String)
+    this._tagVersion = this.validateType('Tag version', tagVersion, Number)
+    this._patch = this.validateType('Patch', patch, Boolean)
   }
 
-  get tagId() {
-    return this._tagId;
+  get tagId () {
+    return this._tagId
   }
 
-  get name() {
-    return this._name;
+  get name () {
+    return this._name
   }
 
-  get version() {
-    return this._version;
+  get version () {
+    return this._version
   }
 
-  get tagVersion() {
-    return this._tagVersion;
+  get tagVersion () {
+    return this._tagVersion
   }
 
-  get patch() {
-    return this._patch;
+  get patch () {
+    return this._patch
   }
 
-  get attachmentText() {
-    return this._attachmentText;
+  get attachmentText () {
+    return this._attachmentText
   }
 
-  set attachmentText(value) {
-    this._attachmentText = this.validateType("Attachment text", value, AttachmentText);
+  set attachmentText (value) {
+    this._attachmentText = this.validateType('Attachment text', value, AttachmentText)
   }
 
-  toJSON() {
+  toJSON () {
     return {
       tagId: this._tagId,
       name: this._name,
@@ -73,10 +73,10 @@ class Swid extends CycloneDXObject {
       tagVersion: this._tagVersion,
       patch: this._patch,
       text: (this._attachmentText) ? this._attachmentText.toJSON() : undefined
-    };
+    }
   }
 
-  toXML() {
+  toXML () {
     return {
       '@tagId': this._tagId,
       '@name': this._name,
@@ -84,8 +84,8 @@ class Swid extends CycloneDXObject {
       '@tagVersion': this._tagVersion,
       '@patch': this._patch,
       text: (this._attachmentText) ? this._attachmentText.toXML() : undefined
-    };
+    }
   }
 }
 
-module.exports = Swid;
+module.exports = Swid

--- a/model/Tool.js
+++ b/model/Tool.js
@@ -16,81 +16,81 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const CycloneDXObject = require('./CycloneDXObject');
+
+const CycloneDXObject = require('./CycloneDXObject')
 
 class Tool extends CycloneDXObject {
-
-  constructor(vendor, name, version, hashes = []) {
-    super();
-    this._vendor = this.validateType("Vendor", vendor, String);
-    this._name = this.validateType("Name", name, String);
-    this._version = this.validateType("Version", version, String);
-    this._hashes = hashes;
+  constructor (vendor, name, version, hashes = []) {
+    super()
+    this._vendor = this.validateType('Vendor', vendor, String)
+    this._name = this.validateType('Name', name, String)
+    this._version = this.validateType('Version', version, String)
+    this._hashes = hashes
   }
 
-  get vendor() {
-    return this._vendor;
+  get vendor () {
+    return this._vendor
   }
 
-  set vendor(value) {
-    this._vendor = this.validateType("Vendor", value, String);
+  set vendor (value) {
+    this._vendor = this.validateType('Vendor', value, String)
   }
 
-  get name() {
-    return this._name;
+  get name () {
+    return this._name
   }
 
-  set name(value) {
-    this._name = this.validateType("Name", value, String);
+  set name (value) {
+    this._name = this.validateType('Name', value, String)
   }
 
-  get version() {
-    return this._version;
+  get version () {
+    return this._version
   }
 
-  set version(value) {
-    this._version = this.validateType("Version", value, String);
+  set version (value) {
+    this._version = this.validateType('Version', value, String)
   }
 
-  get hashes() {
-    return this._hashes;
+  get hashes () {
+    return this._hashes
   }
 
-  set hashes(value) {
-    this._hashes = value;
+  set hashes (value) {
+    this._hashes = value
   }
 
-  processArray(array, format) {
-    let value = [];
+  processArray (array, format) {
+    const value = []
     for (const object of array) {
       if (format === 'XML') {
-        value.push(object.toXML());
+        value.push(object.toXML())
       } else if (format === 'JSON') {
-        value.push(object.toJSON());
+        value.push(object.toJSON())
       }
     }
-    return value;
+    return value
   }
 
-  toJSON() {
+  toJSON () {
     return {
       vendor: this._vendor,
       name: this._name,
       version: this._version,
-      hashes: (this._hashes && this.hashes.length > 0) ? this.processArray(this._hashes, "JSON") : undefined,
+      hashes: (this._hashes && this.hashes.length > 0) ? this.processArray(this._hashes, 'JSON') : undefined
     }
   }
 
-  toXML() {
+  toXML () {
     return {
       tool: {
         vendor: this._vendor,
         name: this._name,
         version: this._version,
-        hashes: (this._hashes && this.hashes.length > 0) ? this.processArray(this._hashes, "XML") : undefined,
+        hashes: (this._hashes && this.hashes.length > 0) ? this.processArray(this._hashes, 'XML') : undefined
       }
     }
   }
 }
 
-module.exports = Tool;
+module.exports = Tool

--- a/package-lock.json
+++ b/package-lock.json
@@ -456,6 +456,41 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@eslint/eslintrc": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
+      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.20",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -804,6 +839,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
     "@types/node": {
       "version": "16.11.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.11.tgz",
@@ -872,6 +913,12 @@
         }
       }
     },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true
+    },
     "acorn-walk": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
@@ -886,6 +933,24 @@
       "requires": {
         "debug": "4"
       }
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -930,10 +995,51 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-includes": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
+      "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "is-string": "^1.0.7"
+      }
+    },
+    "array.prototype.flat": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
+      "integrity": "sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0"
+      }
+    },
+    "array.prototype.flatmap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz",
+      "integrity": "sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0"
+      }
+    },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1097,6 +1203,16 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
     },
     "callsites": {
       "version": "3.1.0",
@@ -1293,6 +1409,15 @@
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1319,6 +1444,15 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.4.0.tgz",
       "integrity": "sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==",
       "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "domexception": {
       "version": "2.0.1",
@@ -1355,6 +1489,63 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
+        "object-inspect": "^1.11.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
@@ -1380,11 +1571,522 @@
         "source-map": "~0.6.1"
       }
     },
+    "eslint": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.18.0.tgz",
+      "integrity": "sha512-fbgTiE8BfUJZuBeq2Yi7J3RB3WGUQ9PNuNbmgi6jt9Iv8qrkxfy19Ds3OpL1Pm7zg3BtTVhvcUZbIRQ0wmSjAQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.3.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^6.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.20",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^6.0.4",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "levn": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+          "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
+          }
+        },
+        "optionator": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+          "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+          "dev": true,
+          "requires": {
+            "deep-is": "^0.1.3",
+            "fast-levenshtein": "^2.0.6",
+            "levn": "^0.4.1",
+            "prelude-ls": "^1.2.1",
+            "type-check": "^0.4.0",
+            "word-wrap": "^1.2.3"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+          "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "type-check": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+          "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-config-standard": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
+      "integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
+      "dev": true
+    },
+    "eslint-config-standard-jsx": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-10.0.0.tgz",
+      "integrity": "sha512-hLeA2f5e06W1xyr/93/QJulN/rLbUVUmqTlexv9PRKHFwEC9ffJcH2LvJhMoEqYQBEYafedgGZXH2W8NUpt5lA==",
+      "dev": true
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.7",
+        "resolve": "^1.20.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.1.tgz",
+      "integrity": "sha512-fjoetBXQZq2tSTWZ9yWVl2KuFrTZZH3V+9iD1V1RfpDgxzJR+mPd/KZmMiA8gbPqdBzpNiEHOuT7IYEWxrH0zQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.7",
+        "find-up": "^2.1.0",
+        "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-es": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.2.tgz",
+      "integrity": "sha512-hNVtyhiEtZmpsabL4neEj+6M5DCLgpYyG9nzJY8lZQeQXEn5UPW1DpUdsMHMXsq98dbNm7nt1w9ZMSVpfJdi8Q==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.3",
+        "array.prototype.flat": "^1.2.4",
+        "debug": "^2.6.9",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-module-utils": "^2.6.2",
+        "find-up": "^2.0.0",
+        "has": "^1.0.3",
+        "is-core-module": "^2.6.0",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.4",
+        "pkg-up": "^2.0.0",
+        "read-pkg-up": "^3.0.0",
+        "resolve": "^1.20.0",
+        "tsconfig-paths": "^3.11.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "eslint-plugin-node": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
+      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-es": "^3.0.0",
+        "eslint-utils": "^2.0.0",
+        "ignore": "^5.1.1",
+        "minimatch": "^3.0.4",
+        "resolve": "^1.10.1",
+        "semver": "^6.1.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.9",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
+          "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.1.1.tgz",
+      "integrity": "sha512-XgdcdyNzHfmlQyweOPTxmc7pIsS6dE4MvwhXWMQ2Dxs1XAL2GJDilUsjWen6TWik0aSI+zD/PqocZBblcm9rdA==",
+      "dev": true
+    },
+    "eslint-plugin-react": {
+      "version": "7.25.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.25.3.tgz",
+      "integrity": "sha512-ZMbFvZ1WAYSZKY662MBVEWR45VaBT6KSJCiupjrNlcdakB90juaZeDCbJq19e73JZQubqFtgETohwgAt8u5P6w==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.3",
+        "array.prototype.flatmap": "^1.2.4",
+        "doctrine": "^2.1.0",
+        "estraverse": "^5.2.0",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.0.4",
+        "object.entries": "^1.1.4",
+        "object.fromentries": "^2.0.4",
+        "object.hasown": "^1.0.0",
+        "object.values": "^1.1.4",
+        "prop-types": "^15.7.2",
+        "resolve": "^2.0.0-next.3",
+        "string.prototype.matchall": "^4.0.5"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "resolve": {
+          "version": "2.0.0-next.3",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz",
+          "integrity": "sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "dev": true
+    },
+    "espree": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      }
     },
     "estraverse": {
       "version": "5.3.0",
@@ -1443,6 +2145,12 @@
         }
       }
     },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1464,6 +2172,15 @@
         "bser": "2.1.1"
       }
     },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1482,6 +2199,22 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+      "dev": true
     },
     "form-data": {
       "version": "3.0.1",
@@ -1512,6 +2245,12 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1524,10 +2263,27 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
       "dev": true
     },
     "get-stream": {
@@ -1535,6 +2291,16 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      }
     },
     "glob": {
       "version": "7.1.6",
@@ -1547,6 +2313,15 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "globals": {
@@ -1569,11 +2344,32 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "dev": true
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
     },
     "hosted-git-info": {
       "version": "2.8.9",
@@ -1631,6 +2427,30 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
+    },
     "import-local": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.3.tgz",
@@ -1661,6 +2481,48 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-callable": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "dev": true
+    },
     "is-core-module": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
@@ -1669,6 +2531,21 @@
       "requires": {
         "has": "^1.0.3"
       }
+    },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -1682,16 +2559,56 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
     },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "dev": true
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-number-object": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
       "dev": true
     },
     "is-stream": {
@@ -1700,11 +2617,38 @@
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
     },
+    "is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "is-weakref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
     },
     "isexe": {
       "version": "2.0.0",
@@ -2427,6 +3371,18 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
     "json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -2434,6 +3390,16 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "jsx-ast-utils": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
+      "integrity": "sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.3",
+        "object.assign": "^4.1.2"
       }
     },
     "kleur": {
@@ -2458,6 +3424,26 @@
         "type-check": "~0.3.2"
       }
     },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -2472,6 +3458,21 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -2640,6 +3641,79 @@
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.1.tgz",
+      "integrity": "sha512-If7BjFlpkzzBeV1cqgT3OSWT3azyoxDGajR+iGnFBfVV2EWyDyWaZZW2ERDjUaY2QM8i5jI3Sj7mhsM4DDAqWA==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+      "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz",
+      "integrity": "sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.hasown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
+      "integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
+    "object.values": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
+      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2700,6 +3774,25 @@
       "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-0.0.5.tgz",
       "integrity": "sha512-BISQVKLiu7EsWF5Qhx8OvX6K5vOfFcYuQBggFfrF2dHu+/Z2snuabilb0EyLvHZH0XXqbEz20pqFRonTt8z6QA=="
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
+    },
     "parse-packagejson-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-packagejson-name/-/parse-packagejson-name-1.0.1.tgz",
@@ -2733,6 +3826,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      }
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -2745,6 +3847,12 @@
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
     },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
+    },
     "pirates": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -2754,6 +3862,83 @@
         "node-modules-regexp": "^1.0.0"
       }
     },
+    "pkg-conf": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
+      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "load-json-file": "^5.2.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "parse-json": "^4.0.0",
+            "pify": "^4.0.1",
+            "strip-bom": "^3.0.0",
+            "type-fest": "^0.3.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
+        }
+      }
+    },
     "pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -2761,6 +3946,66 @@
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
+      }
+    },
+    "pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
       }
     },
     "prelude-ls": {
@@ -2794,6 +4039,12 @@
         }
       }
     },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -2802,6 +4053,25 @@
       "requires": {
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        }
       }
     },
     "psl": {
@@ -2848,6 +4118,78 @@
         "npm-normalize-package-bin": "^1.0.0"
       }
     },
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.0.0",
+        "read-pkg": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
     "readdir-scoped-modules": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
@@ -2859,10 +4201,32 @@
         "once": "^1.3.0"
       }
     },
+    "regexp.prototype.flags": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
+      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "resolve": {
@@ -2944,6 +4308,17 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
@@ -2961,6 +4336,17 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      }
     },
     "slide": {
       "version": "1.1.6",
@@ -3042,6 +4428,34 @@
         }
       }
     },
+    "standard": {
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-16.0.4.tgz",
+      "integrity": "sha512-2AGI874RNClW4xUdM+bg1LRXVlYLzTNEkHmTG5mhyn45OhbgwA+6znowkOGYy+WMb5HRyELvtNy39kcdMQMcYQ==",
+      "dev": true,
+      "requires": {
+        "eslint": "~7.18.0",
+        "eslint-config-standard": "16.0.3",
+        "eslint-config-standard-jsx": "10.0.0",
+        "eslint-plugin-import": "~2.24.2",
+        "eslint-plugin-node": "~11.1.0",
+        "eslint-plugin-promise": "~5.1.0",
+        "eslint-plugin-react": "~7.25.1",
+        "standard-engine": "^14.0.1"
+      }
+    },
+    "standard-engine": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-14.0.1.tgz",
+      "integrity": "sha512-7FEzDwmHDOGva7r9ifOzD3BGdTbA7ujJ50afLVdW/tK14zQEptJjbFuUfn50irqdHDcTbNh0DTIoMPynMCXb0Q==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^8.0.0",
+        "minimist": "^1.2.5",
+        "pkg-conf": "^3.1.0",
+        "xdg-basedir": "^4.0.0"
+      }
+    },
     "string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -3063,6 +4477,42 @@
         "strip-ansi": "^6.0.1"
       }
     },
+    "string.prototype.matchall": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz",
+      "integrity": "sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.1",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.2",
+        "internal-slot": "^1.0.3",
+        "regexp.prototype.flags": "^1.3.1",
+        "side-channel": "^1.0.4"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
     "strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -3082,6 +4532,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
     "supports-color": {
@@ -3109,6 +4565,39 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "table": {
+      "version": "6.7.5",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.5.tgz",
+      "integrity": "sha512-LFNeryOqiQHqCVKzhkymKwt6ozeRhlm8IL1mE8rNUurkir4heF6PzMyRgaTa4tlyPTGGgXuvVOF/OLWiH09Lqw==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
+          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
     "terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -3129,6 +4618,12 @@
         "glob": "^7.1.4",
         "minimatch": "^3.0.4"
       }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "throat": {
       "version": "6.0.1",
@@ -3177,6 +4672,35 @@
         "punycode": "^2.1.1"
       }
     },
+    "tsconfig-paths": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
+      "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -3207,11 +4731,32 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "util-extend": {
       "version": "1.0.3",
@@ -3222,6 +4767,12 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
     },
     "v8-to-istanbul": {
       "version": "8.1.0",
@@ -3319,6 +4870,19 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -3357,6 +4921,12 @@
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
       "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+      "dev": true
+    },
+    "xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
     },
     "xml": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
     "cyclonedx-node": "./bin/make-bom.js"
   },
   "scripts": {
-    "test": "jest",
+    "test": "npm run test:standard && npm run test:unit",
+    "test:unit": "jest",
+    "test:standard": "standard -v",
+    "cs-fix": "standard --fix",
     "docker-release": "docker build . -t cyclonedx/cyclonedx-node:`node bin/make-bom.js --version` -t cyclonedx/cyclonedx-node:latest && docker push cyclonedx/cyclonedx-node:`node bin/make-bom.js --version` && docker push cyclonedx/cyclonedx-node:latest"
   },
   "engines": {
@@ -70,7 +73,8 @@
   ],
   "devDependencies": {
     "jest": "^27.1.0",
-    "jest-junit": "^13.0.0"
+    "jest-junit": "^13.0.0",
+    "standard": "^16.0.4"
   },
   "jest": {
     "cacheDirectory": ".jest.cache",

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -19,73 +19,73 @@
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
 
-const bomHelpers = require("../index.js");
+const bomHelpers = require('../index.js')
 
-const timestamp = new Date("2020-01-01T01:00:00.000Z");
-const programVersion = "3.0.0";
+const timestamp = new Date('2020-01-01T01:00:00.000Z')
+const programVersion = '3.0.0'
 
 test('createbom produces an empty BOM', done => {
-  bomHelpers.createbom("library", false, false, './tests/no-packages', {}, (err, bom) => {
-    expect(err).toBeFalsy();
+  bomHelpers.createbom('library', false, false, './tests/no-packages', {}, (err, bom) => {
+    expect(err).toBeFalsy()
 
-    bom.metadata.timestamp = timestamp;
-    bom.metadata.tools[0].version = programVersion;
-    expect(bom.toXML()).toMatchSnapshot();
-    done();
-  });
-});
+    bom.metadata.timestamp = timestamp
+    bom.metadata.tools[0].version = programVersion
+    expect(bom.toXML()).toMatchSnapshot()
+    done()
+  })
+})
 
 test('createbom produces a BOM without development dependencies', done => {
-  bomHelpers.createbom("library", false, true, './tests/with-packages', {}, (err, bom) => {
-    expect(err).toBeFalsy();
+  bomHelpers.createbom('library', false, true, './tests/with-packages', {}, (err, bom) => {
+    expect(err).toBeFalsy()
 
-    bom.metadata.timestamp = timestamp;
-    bom.metadata.tools[0].version = programVersion;
-    expect(bom.toXML()).toMatchSnapshot();
-    done();
-  });
-});
+    bom.metadata.timestamp = timestamp
+    bom.metadata.tools[0].version = programVersion
+    expect(bom.toXML()).toMatchSnapshot()
+    done()
+  })
+})
 
 test('createbom produces a BOM with development dependencies', done => {
-  bomHelpers.createbom("library", false, true, './tests/with-packages', { dev: true }, (err, bom) => {
-    expect(err).toBeFalsy();
+  bomHelpers.createbom('library', false, true, './tests/with-packages', { dev: true }, (err, bom) => {
+    expect(err).toBeFalsy()
 
-    bom.metadata.timestamp = timestamp;
-    bom.metadata.tools[0].version = programVersion;
-    expect(bom.toXML()).toMatchSnapshot();
-    done();
-  });
-});
+    bom.metadata.timestamp = timestamp
+    bom.metadata.tools[0].version = programVersion
+    expect(bom.toXML()).toMatchSnapshot()
+    done()
+  })
+})
 
 test('createbom produces a BOM in JSON format', done => {
-  bomHelpers.createbom("library", false, true, './tests/with-packages', {}, (err, bom) => {
-    expect(err).toBeFalsy();
+  bomHelpers.createbom('library', false, true, './tests/with-packages', {}, (err, bom) => {
+    expect(err).toBeFalsy()
 
-    bom.metadata.timestamp = timestamp;
-    bom.metadata.tools[0].version = programVersion;
-    expect(bom.toJSON()).toMatchSnapshot();
-    done();
-  });
-});
+    bom.metadata.timestamp = timestamp
+    bom.metadata.tools[0].version = programVersion
+    expect(bom.toJSON()).toMatchSnapshot()
+    done()
+  })
+})
 
 test('createbom produces a BOM in JSON format that includes hashes from package-lock.json', done => {
-  bomHelpers.createbom("library", false, true, './tests/with-lockfile-2', {}, (err, bom) => {
-    expect(err).toBeFalsy();
+  bomHelpers.createbom('library', false, true, './tests/with-lockfile-2', {}, (err, bom) => {
+    expect(err).toBeFalsy()
 
-    bom.metadata.timestamp = timestamp;
-    bom.metadata.tools[0].version = programVersion;
-    expect(bom.toJSON()).toMatchSnapshot();
-    done();
-  });
-});
+    bom.metadata.timestamp = timestamp
+    bom.metadata.tools[0].version = programVersion
+    expect(bom.toJSON()).toMatchSnapshot()
+    done()
+  })
+})
 
 test('createbom produces a BOM when no package-lock.json is present', done => {
-  bomHelpers.createbom("library", false, true, './tests/no-lockfile', {}, (err, bom) => {
-    expect(err).toBeFalsy();
+  bomHelpers.createbom('library', false, true, './tests/no-lockfile', {}, (err, bom) => {
+    expect(err).toBeFalsy()
 
-    bom.metadata.timestamp = timestamp;
-    bom.metadata.tools[0].version = programVersion;
-    expect(bom.toJSON()).toMatchSnapshot();
-    done();
-  });
-});
+    bom.metadata.timestamp = timestamp
+    bom.metadata.tools[0].version = programVersion
+    expect(bom.toJSON()).toMatchSnapshot()
+    done()
+  })
+})

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,3 +1,24 @@
+/* eslint-env jest */
+
+/*
+ * This file is part of CycloneDX Node Module.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+
 const bomHelpers = require("../index.js");
 
 const timestamp = new Date("2020-01-01T01:00:00.000Z");

--- a/tests/model/Bom.test.js
+++ b/tests/model/Bom.test.js
@@ -18,25 +18,26 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const Bom = require('../../model/Bom');
+
+const Bom = require('../../model/Bom')
 
 test('default schema version', () => {
-  let bom = new Bom();
-  expect(bom.schemaVersion).toBe('1.3');
-});
+  const bom = new Bom()
+  expect(bom.schemaVersion).toBe('1.3')
+})
 
 test('default bom version', () => {
-  let bom = new Bom();
-  expect(bom.version).toBe(1);
-});
+  const bom = new Bom()
+  expect(bom.version).toBe(1)
+})
 
 test('specific bom version', () => {
-  let bom = new Bom();
-  bom.version = 2;
-  expect(bom.version).toBe(2);
-});
+  const bom = new Bom()
+  bom.version = 2
+  expect(bom.version).toBe(2)
+})
 
 test('generated serial number', () => {
-  let bom = new Bom();
-  expect(bom.serialNumber).toContain('urn:uuid:');
-});
+  const bom = new Bom()
+  expect(bom.serialNumber).toContain('urn:uuid:')
+})

--- a/tests/model/Bom.test.js
+++ b/tests/model/Bom.test.js
@@ -1,3 +1,5 @@
+/* eslint-env jest */
+
 /*
  * This file is part of CycloneDX Node Module.
  *

--- a/tests/model/Component.test.js
+++ b/tests/model/Component.test.js
@@ -1,3 +1,5 @@
+/* eslint-env jest */
+
 /*
  * This file is part of CycloneDX Node Module.
  *

--- a/tests/model/Component.test.js
+++ b/tests/model/Component.test.js
@@ -18,93 +18,93 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const Component = require('../../model/Component');
-const Hash = require('../../model/Hash');
-const HashList = require('../../model/HashList');
-const License = require('../../model/License');
-const LicenseChoice = require('../../model/LicenseChoice');
-const OrganizationalContact = require('../../model/OrganizationalContact');
-const OrganizationalEntity = require('../../model/OrganizationalEntity');
-const Swid = require('../../model/Swid');
 
+const Component = require('../../model/Component')
+const Hash = require('../../model/Hash')
+const HashList = require('../../model/HashList')
+const License = require('../../model/License')
+const LicenseChoice = require('../../model/LicenseChoice')
+const OrganizationalContact = require('../../model/OrganizationalContact')
+const OrganizationalEntity = require('../../model/OrganizationalEntity')
+const Swid = require('../../model/Swid')
 
 test('Model: Component / Format: XML', () => {
-  let result = createComponent().toXML();
-  expect(result.component['@type']).toBe("application");
-  expect(result.component['@bom-ref']).toBe("12345");
-  expect(result.component.supplier.name).toBe("Acme R&D");
-  expect(result.component.supplier.url).toBe("https://example.com/r&d");
-  expect(result.component.supplier.contact.name).toBe("John Doe");
-  expect(result.component.supplier.contact.email).toBe("john.doe@example.com");
-  expect(result.component.supplier.contact.phone).toBe("555-1212");
-  expect(result.component.author).toBe("Acme Development Team");
-  expect(result.component.publisher).toBe("Example Inc");
-  expect(result.component.group).toBe("com.example");
-  expect(result.component.name).toBe("sample-app");
-  expect(result.component.version).toBe("1.0.0");
-  expect(result.component.description['#cdata']).toBe("A sample application");
-  expect(result.component.scope).toBe("required");
-  expect(result.component.hashes[0].hash['@alg']).toBe("SHA-1");
-  expect(result.component.hashes[0].hash['#text']).toBe("da39a3ee5e6b4b0d3255bfef95601890afd80709");
-  expect(result.component.licenses[0].license.id).toBe("Apache-2.0");
-  expect(result.component.copyright).toBe("Copyright 2020 Example Inc.");
-  expect(result.component.cpe).toBe("cpe:2.3:a:example:sample-app:*:*:*:*:*:*:*:*");
-  expect(result.component.purl).toBe("pkg:maven/com.example/sample-app@1.0.0");
-  expect(result.component.swid['@tagId']).toBe("example-com-sample-app");
-  expect(result.component.swid['@name']).toBe("Sample App");
-  expect(result.component.swid['@version']).toBe("1.0.0");
-});
+  const result = createComponent().toXML()
+  expect(result.component['@type']).toBe('application')
+  expect(result.component['@bom-ref']).toBe('12345')
+  expect(result.component.supplier.name).toBe('Acme R&D')
+  expect(result.component.supplier.url).toBe('https://example.com/r&d')
+  expect(result.component.supplier.contact.name).toBe('John Doe')
+  expect(result.component.supplier.contact.email).toBe('john.doe@example.com')
+  expect(result.component.supplier.contact.phone).toBe('555-1212')
+  expect(result.component.author).toBe('Acme Development Team')
+  expect(result.component.publisher).toBe('Example Inc')
+  expect(result.component.group).toBe('com.example')
+  expect(result.component.name).toBe('sample-app')
+  expect(result.component.version).toBe('1.0.0')
+  expect(result.component.description['#cdata']).toBe('A sample application')
+  expect(result.component.scope).toBe('required')
+  expect(result.component.hashes[0].hash['@alg']).toBe('SHA-1')
+  expect(result.component.hashes[0].hash['#text']).toBe('da39a3ee5e6b4b0d3255bfef95601890afd80709')
+  expect(result.component.licenses[0].license.id).toBe('Apache-2.0')
+  expect(result.component.copyright).toBe('Copyright 2020 Example Inc.')
+  expect(result.component.cpe).toBe('cpe:2.3:a:example:sample-app:*:*:*:*:*:*:*:*')
+  expect(result.component.purl).toBe('pkg:maven/com.example/sample-app@1.0.0')
+  expect(result.component.swid['@tagId']).toBe('example-com-sample-app')
+  expect(result.component.swid['@name']).toBe('Sample App')
+  expect(result.component.swid['@version']).toBe('1.0.0')
+})
 
 test('Model: Component / Format: JSON', () => {
-  let result = createComponent().toJSON();
-  expect(result.type).toBe("application");
-  expect(result['bom-ref']).toBe("12345");
-  expect(result.supplier.name).toBe("Acme R&D");
-  expect(result.supplier.url[0]).toBe("https://example.com/r&d");
-  expect(result.supplier.contact[0].name).toBe("John Doe");
-  expect(result.supplier.contact[0].email).toBe("john.doe@example.com");
-  expect(result.supplier.contact[0].phone).toBe("555-1212");
-  expect(result.author).toBe("Acme Development Team");
-  expect(result.publisher).toBe("Example Inc");
-  expect(result.group).toBe("com.example");
-  expect(result.name).toBe("sample-app");
-  expect(result.version).toBe("1.0.0");
-  expect(result.description).toBe("A sample application");
-  expect(result.scope).toBe("required");
-  expect(result.hashes[0].alg).toBe("SHA-1");
-  expect(result.hashes[0].content).toBe("da39a3ee5e6b4b0d3255bfef95601890afd80709");
-  expect(result.licenses[0].license.id).toBe("Apache-2.0");
-  expect(result.copyright).toBe("Copyright 2020 Example Inc.");
-  expect(result.cpe).toBe("cpe:2.3:a:example:sample-app:*:*:*:*:*:*:*:*");
-  expect(result.purl).toBe("pkg:maven/com.example/sample-app@1.0.0");
-  expect(result.swid.tagId).toBe("example-com-sample-app");
-  expect(result.swid.name).toBe("Sample App");
-  expect(result.swid.version).toBe("1.0.0");
-});
+  const result = createComponent().toJSON()
+  expect(result.type).toBe('application')
+  expect(result['bom-ref']).toBe('12345')
+  expect(result.supplier.name).toBe('Acme R&D')
+  expect(result.supplier.url[0]).toBe('https://example.com/r&d')
+  expect(result.supplier.contact[0].name).toBe('John Doe')
+  expect(result.supplier.contact[0].email).toBe('john.doe@example.com')
+  expect(result.supplier.contact[0].phone).toBe('555-1212')
+  expect(result.author).toBe('Acme Development Team')
+  expect(result.publisher).toBe('Example Inc')
+  expect(result.group).toBe('com.example')
+  expect(result.name).toBe('sample-app')
+  expect(result.version).toBe('1.0.0')
+  expect(result.description).toBe('A sample application')
+  expect(result.scope).toBe('required')
+  expect(result.hashes[0].alg).toBe('SHA-1')
+  expect(result.hashes[0].content).toBe('da39a3ee5e6b4b0d3255bfef95601890afd80709')
+  expect(result.licenses[0].license.id).toBe('Apache-2.0')
+  expect(result.copyright).toBe('Copyright 2020 Example Inc.')
+  expect(result.cpe).toBe('cpe:2.3:a:example:sample-app:*:*:*:*:*:*:*:*')
+  expect(result.purl).toBe('pkg:maven/com.example/sample-app@1.0.0')
+  expect(result.swid.tagId).toBe('example-com-sample-app')
+  expect(result.swid.name).toBe('Sample App')
+  expect(result.swid.version).toBe('1.0.0')
+})
 
-function createComponent() {
-  let component = new Component();
-  component.type = "application";
-  component.bomRef = "12345";
-  component.supplier = new OrganizationalEntity("Acme R&D", "https://example.com/r&d", new OrganizationalContact("John Doe", "john.doe@example.com", "555-1212"));
-  component.author = "Acme Development Team";
-  component.publisher = "Example Inc";
-  component.group = "com.example";
-  component.name = "sample-app";
-  component.version = "1.0.0";
-  component.description = "A sample application";
-  component.scope = "required";
-  let hashList = new HashList();
-  hashList.hashes.push(new Hash("SHA-1", "da39a3ee5e6b4b0d3255bfef95601890afd80709"));
-  component.hashes = hashList;
-  let license = new License();
-  license.id = "Apache-2.0";
-  let licenseChoice = new LicenseChoice();
-  licenseChoice.licenses = [license];
-  component.licenses = licenseChoice;
-  component.copyright = "Copyright 2020 Example Inc.";
-  component.cpe = "cpe:2.3:a:example:sample-app:*:*:*:*:*:*:*:*";
-  component.purl = "pkg:maven/com.example/sample-app@1.0.0";
-  component.swid = new Swid("example-com-sample-app", "Sample App", "1.0.0");
-  return component;
+function createComponent () {
+  const component = new Component()
+  component.type = 'application'
+  component.bomRef = '12345'
+  component.supplier = new OrganizationalEntity('Acme R&D', 'https://example.com/r&d', new OrganizationalContact('John Doe', 'john.doe@example.com', '555-1212'))
+  component.author = 'Acme Development Team'
+  component.publisher = 'Example Inc'
+  component.group = 'com.example'
+  component.name = 'sample-app'
+  component.version = '1.0.0'
+  component.description = 'A sample application'
+  component.scope = 'required'
+  const hashList = new HashList()
+  hashList.hashes.push(new Hash('SHA-1', 'da39a3ee5e6b4b0d3255bfef95601890afd80709'))
+  component.hashes = hashList
+  const license = new License()
+  license.id = 'Apache-2.0'
+  const licenseChoice = new LicenseChoice()
+  licenseChoice.licenses = [license]
+  component.licenses = licenseChoice
+  component.copyright = 'Copyright 2020 Example Inc.'
+  component.cpe = 'cpe:2.3:a:example:sample-app:*:*:*:*:*:*:*:*'
+  component.purl = 'pkg:maven/com.example/sample-app@1.0.0'
+  component.swid = new Swid('example-com-sample-app', 'Sample App', '1.0.0')
+  return component
 }

--- a/tests/model/Metadata.test.js
+++ b/tests/model/Metadata.test.js
@@ -18,68 +18,68 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const Bom = require('../../model/Bom');
-const Component = require('../../model/Component');
-const Metadata = require('../../model/Metadata');
-const OrganizationalContact = require('../../model/OrganizationalContact');
-const OrganizationalEntity = require('../../model/OrganizationalEntity');
-const Tool = require('../../model/Tool');
 
+const Bom = require('../../model/Bom')
+const Component = require('../../model/Component')
+const Metadata = require('../../model/Metadata')
+const OrganizationalContact = require('../../model/OrganizationalContact')
+const OrganizationalEntity = require('../../model/OrganizationalEntity')
+const Tool = require('../../model/Tool')
 
 test('Model: Metadata / Format: XML', () => {
-  let result = createMetadata().toXML();
-  expect(new Date(result.timestamp)).toBeInstanceOf(Date);
-  expect(result.tools[0].tool.vendor).toBe("Acme");
-  expect(result.tools[0].tool.name).toBe("My tool");
-  expect(result.tools[0].tool.version).toBe("2.2.0");
-  expect(result.manufacture.name).toBe("Acme R&D");
-  expect(result.manufacture.url).toBe("https://example.com/r&d");
-  expect(result.manufacture.contact.name).toBe("R&D");
-  expect(result.manufacture.contact.email).toBe("rd@example.com");
-  expect(result.manufacture.contact.phone).toBe("555-1212");
-  expect(result.supplier.name).toBe("Acme Wholesale");
-  expect(result.supplier.url).toBe("https://example.com/wholesale");
-  expect(result.supplier.contact.name).toBe("Customer Service");
-  expect(result.supplier.contact.email).toBe("wholesale@example.com");
-  expect(result.supplier.contact.phone).toBe("555-1212");
-  expect(result.component['@type']).toBe("application");
-  expect(result.component.name).toBe("sample-app");
-  expect(result.component.version).toBe("1.0.0");
-});
+  const result = createMetadata().toXML()
+  expect(new Date(result.timestamp)).toBeInstanceOf(Date)
+  expect(result.tools[0].tool.vendor).toBe('Acme')
+  expect(result.tools[0].tool.name).toBe('My tool')
+  expect(result.tools[0].tool.version).toBe('2.2.0')
+  expect(result.manufacture.name).toBe('Acme R&D')
+  expect(result.manufacture.url).toBe('https://example.com/r&d')
+  expect(result.manufacture.contact.name).toBe('R&D')
+  expect(result.manufacture.contact.email).toBe('rd@example.com')
+  expect(result.manufacture.contact.phone).toBe('555-1212')
+  expect(result.supplier.name).toBe('Acme Wholesale')
+  expect(result.supplier.url).toBe('https://example.com/wholesale')
+  expect(result.supplier.contact.name).toBe('Customer Service')
+  expect(result.supplier.contact.email).toBe('wholesale@example.com')
+  expect(result.supplier.contact.phone).toBe('555-1212')
+  expect(result.component['@type']).toBe('application')
+  expect(result.component.name).toBe('sample-app')
+  expect(result.component.version).toBe('1.0.0')
+})
 
 test('Model: Metadata / Format: JSON', () => {
-  let result = createMetadata().toJSON();
-  expect(new Date(result.timestamp)).toBeInstanceOf(Date);
-  expect(result.tools[0].vendor).toBe("Acme");
-  expect(result.tools[0].name).toBe("My tool");
-  expect(result.tools[0].version).toBe("2.2.0");
-  expect(result.manufacture.name).toBe("Acme R&D");
-  expect(result.manufacture.url[0]).toBe("https://example.com/r&d");
-  expect(result.manufacture.contact[0].name).toBe("R&D");
-  expect(result.manufacture.contact[0].email).toBe("rd@example.com");
-  expect(result.manufacture.contact[0].phone).toBe("555-1212");
-  expect(result.supplier.name).toBe("Acme Wholesale");
-  expect(result.supplier.url[0]).toBe("https://example.com/wholesale");
-  expect(result.supplier.contact[0].name).toBe("Customer Service");
-  expect(result.supplier.contact[0].email).toBe("wholesale@example.com");
-  expect(result.supplier.contact[0].phone).toBe("555-1212");
-  expect(result.component['type']).toBe("application");
-  expect(result.component.name).toBe("sample-app");
-  expect(result.component.version).toBe("1.0.0");
-});
+  const result = createMetadata().toJSON()
+  expect(new Date(result.timestamp)).toBeInstanceOf(Date)
+  expect(result.tools[0].vendor).toBe('Acme')
+  expect(result.tools[0].name).toBe('My tool')
+  expect(result.tools[0].version).toBe('2.2.0')
+  expect(result.manufacture.name).toBe('Acme R&D')
+  expect(result.manufacture.url[0]).toBe('https://example.com/r&d')
+  expect(result.manufacture.contact[0].name).toBe('R&D')
+  expect(result.manufacture.contact[0].email).toBe('rd@example.com')
+  expect(result.manufacture.contact[0].phone).toBe('555-1212')
+  expect(result.supplier.name).toBe('Acme Wholesale')
+  expect(result.supplier.url[0]).toBe('https://example.com/wholesale')
+  expect(result.supplier.contact[0].name).toBe('Customer Service')
+  expect(result.supplier.contact[0].email).toBe('wholesale@example.com')
+  expect(result.supplier.contact[0].phone).toBe('555-1212')
+  expect(result.component.type).toBe('application')
+  expect(result.component.name).toBe('sample-app')
+  expect(result.component.version).toBe('1.0.0')
+})
 
-function createMetadata() {
-  let bom = new Bom();
-  let metadata = new Metadata();
-  metadata.tools = [new Tool("Acme", "My tool", "2.2.0")];
-  metadata.authors = [new OrganizationalContact("Jane Doe", "jane.doe@example.com", "555-1212")];
-  metadata.manufacture = new OrganizationalEntity("Acme R&D", "https://example.com/r&d", new OrganizationalContact("R&D", "rd@example.com", "555-1212"));
-  metadata.supplier = new OrganizationalEntity("Acme Wholesale", "https://example.com/wholesale", new OrganizationalContact("Customer Service", "wholesale@example.com", "555-1212"));
-  let component = new Component();
-  component.type = "application";
-  component.name = "sample-app";
-  component.version = "1.0.0";
-  metadata.component = component;
-  bom.metadata = metadata;
-  return metadata;
+function createMetadata () {
+  const bom = new Bom()
+  const metadata = new Metadata()
+  metadata.tools = [new Tool('Acme', 'My tool', '2.2.0')]
+  metadata.authors = [new OrganizationalContact('Jane Doe', 'jane.doe@example.com', '555-1212')]
+  metadata.manufacture = new OrganizationalEntity('Acme R&D', 'https://example.com/r&d', new OrganizationalContact('R&D', 'rd@example.com', '555-1212'))
+  metadata.supplier = new OrganizationalEntity('Acme Wholesale', 'https://example.com/wholesale', new OrganizationalContact('Customer Service', 'wholesale@example.com', '555-1212'))
+  const component = new Component()
+  component.type = 'application'
+  component.name = 'sample-app'
+  component.version = '1.0.0'
+  metadata.component = component
+  bom.metadata = metadata
+  return metadata
 }

--- a/tests/model/Metadata.test.js
+++ b/tests/model/Metadata.test.js
@@ -1,3 +1,5 @@
+/* eslint-env jest */
+
 /*
  * This file is part of CycloneDX Node Module.
  *

--- a/tests/model/OrganizationalContact.test.js
+++ b/tests/model/OrganizationalContact.test.js
@@ -18,20 +18,21 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright (c) OWASP Foundation. All Rights Reserved.
  */
-const OrganizationalContact = require('../../model/OrganizationalContact');
+
+const OrganizationalContact = require('../../model/OrganizationalContact')
 
 test('Model: OrganizationalContact / Format: XML', () => {
-  let contact = new OrganizationalContact("John Doe", "john.doe@examp.com", "555-1212");
-  let result = contact.toXML();
-  expect(result.name).toBe("John Doe");
-  expect(result.email).toBe("john.doe@examp.com");
-  expect(result.phone).toBe("555-1212");
-});
+  const contact = new OrganizationalContact('John Doe', 'john.doe@examp.com', '555-1212')
+  const result = contact.toXML()
+  expect(result.name).toBe('John Doe')
+  expect(result.email).toBe('john.doe@examp.com')
+  expect(result.phone).toBe('555-1212')
+})
 
 test('Model: OrganizationalContact / Format: JSON', () => {
-  let contact = new OrganizationalContact("John Doe", "john.doe@examp.com", "555-1212");
-  let result = contact.toJSON();
-  expect(result.name).toBe("John Doe");
-  expect(result.email).toBe("john.doe@examp.com");
-  expect(result.phone).toBe("555-1212");
-});
+  const contact = new OrganizationalContact('John Doe', 'john.doe@examp.com', '555-1212')
+  const result = contact.toJSON()
+  expect(result.name).toBe('John Doe')
+  expect(result.email).toBe('john.doe@examp.com')
+  expect(result.phone).toBe('555-1212')
+})

--- a/tests/model/OrganizationalContact.test.js
+++ b/tests/model/OrganizationalContact.test.js
@@ -1,3 +1,5 @@
+/* eslint-env jest */
+
 /*
  * This file is part of CycloneDX Node Module.
  *


### PR DESCRIPTION
supersedes #196 - thanks @Anthony-Mckale @mckalea
fixes  #194

----

* Changed
  * Errors are no longer thrown as `String`, but inherited `Error`.
    This is considered a none-breaking change,
    as `Error.toString()` returns the original error message.
* Fixed
  * `ExternalReference.type` setter sets value correctly now.
    Setter caused an Error or set to `undefined` in the past.
  * `AttachmentText` sets `encoding` correctly via setter and constructor now.
    Set to `undefined` in the past.

----

- [x] add coding standards and apply them
- [x] add tests for coding standards 
- [x] fix all standards violations
- [x] proper code review by author