### PR TITLE
fix: brought back `bin/cyclonedx-bom` compat layer

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Fixed
+  * Brought deprecated file `bin/cyclonedx-bom` back. (via [#224])  
+    File is now a compatibility-layer that spits a warning.
+
+[#224]: https://github.com/CycloneDX/cyclonedx-node-module/pull/224
+
 ## 3.3.0 - 2021-12-10
 
 * Changed

--- a/bin/cyclonedx-bom
+++ b/bin/cyclonedx-bom
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+// backwards-compatibility layer.
+// @TODO remove this file in v4
+const path = require('path')
+console.warn(
+  '! ATTENTION\n',
+  'File is deprecated: ' + __filename + '\n',
+  'Use instead: ' + path.join(path.dirname(__filename), 'make-bom.js') + '\n'
+)
+require('./make-bom.js')


### PR DESCRIPTION
brought back the `bin/cyclonedx-bom` file.
as a compatibility layer for people using `.../bin/cyclonedx-bom` as a path in some hardcoded script contexts, instead of using the bin-accessor via `npx`