### PR TITLE
root components with empty name have a fallback

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -56,6 +56,9 @@ jobs:
       - name: install testing-project "with-dev-dependencies"
         run: npm ci
         working-directory: tests/with-dev-dependencies
+      - name: install testing-project "no-name"
+        run: npm ci
+        working-directory: tests/no-name
       - name: run tests
         run: >
           npm run test:unit --

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## unreleased
 
+* Fixed
+  * root-packages without a name no longer cause unexpected crashes ([#252] via [#253])
+
+[#252]: https://github.com/CycloneDX/cyclonedx-node-module/issues/252
+[#253]: https://github.com/CycloneDX/cyclonedx-node-module/pull/253
+
 ## 3.4.0 - 2022-02-02
 
 * Changed

--- a/model/Bom.js
+++ b/model/Bom.js
@@ -35,7 +35,11 @@ class Bom extends CycloneDXObject {
     if (includeSerialNumber) {
       this._serialNumber = 'urn:uuid:' + uuid.v4()
     }
-    if (pkg) {
+    if (pkg && typeof pkg === 'object') {
+      if (!pkg.name) {
+        pkg = Object.assign({}, pkg) // work with a modified/fixed clone
+        pkg.name = 'NO-NAME-PACKAGE'
+      }
       this._metadata = this.createMetadata(pkg, componentType)
       this._components = this.listComponents(pkg, lockfile)
     } else {

--- a/test.sh
+++ b/test.sh
@@ -8,6 +8,7 @@ npm ci
 ## install testing-projects
 npm ci --prefix 'tests/with-packages'
 npm ci --prefix 'tests/with-dev-dependencies'
+npm ci --prefix 'tests/no-name'
 
 ## run tests
 npm test

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -1986,6 +1986,108 @@ exports[`createbom produces a BOM when no package-lock.json is present 1`] = `
 }"
 `;
 
+exports[`createbom produces a BOM when there is no name in the root package 1`] = `
+"{
+  \\"bomFormat\\": \\"CycloneDX\\",
+  \\"specVersion\\": \\"1.3\\",
+  \\"version\\": 1,
+  \\"metadata\\": {
+    \\"timestamp\\": \\"2020-01-01T01:00:00.000Z\\",
+    \\"tools\\": [
+      {
+        \\"vendor\\": \\"CycloneDX\\",
+        \\"name\\": \\"Node.js module\\",
+        \\"version\\": \\"3.0.0\\"
+      }
+    ],
+    \\"component\\": {
+      \\"type\\": \\"library\\",
+      \\"name\\": \\"NO-NAME-PACKAGE\\",
+      \\"version\\": \\"\\",
+      \\"description\\": \\"an package without a name. see https://github.com/CycloneDX/cyclonedx-node-module/issues/252\\"
+    }
+  },
+  \\"components\\": [
+    {
+      \\"type\\": \\"library\\",
+      \\"bom-ref\\": \\"pkg:npm/packageurl-js@0.0.1\\",
+      \\"author\\": \\"the purl authors\\",
+      \\"name\\": \\"packageurl-js\\",
+      \\"version\\": \\"0.0.1\\",
+      \\"description\\": \\"JavaScript library to parse and build \\\\\\"purl\\\\\\" aka. package URLs. This is a microlibrary implementing the purl spec at https://github.com/package-url\\",
+      \\"hashes\\": [
+        {
+          \\"alg\\": \\"SHA-512\\",
+          \\"content\\": \\"863333aba5ee03130c895e7950e2217fa6f25ca47d15cd38eb26eba060a98c6b49e4423d4091bd83f12b6283edd11194680af9d42eb1fa9c141bda5780b9daaa\\"
+        }
+      ],
+      \\"licenses\\": [
+        {
+          \\"license\\": {
+            \\"id\\": \\"MIT\\"
+          }
+        }
+      ],
+      \\"purl\\": \\"pkg:npm/packageurl-js@0.0.1\\",
+      \\"externalReferences\\": [
+        {
+          \\"type\\": \\"website\\",
+          \\"url\\": \\"https://github.com/package-url/packageurl-js#readme\\"
+        },
+        {
+          \\"type\\": \\"issue-tracker\\",
+          \\"url\\": \\"https://github.com/package-url/packageurl-js/issues\\"
+        },
+        {
+          \\"type\\": \\"vcs\\",
+          \\"url\\": \\"git+https://github.com/package-url/packageurl-js.git\\"
+        }
+      ]
+    },
+    {
+      \\"type\\": \\"library\\",
+      \\"bom-ref\\": \\"pkg:npm/urijs@1.19.7\\",
+      \\"author\\": \\"Rodney Rehm\\",
+      \\"name\\": \\"urijs\\",
+      \\"version\\": \\"1.19.7\\",
+      \\"description\\": \\"URI.js is a Javascript library for working with URLs.\\",
+      \\"hashes\\": [
+        {
+          \\"alg\\": \\"SHA-512\\",
+          \\"content\\": \\"21df882a3754d07c7eed9c7bd7b8f02cfb0f794ab3eeb02db950512cbb3eaa7f89da77fd3462135950b17228e063106a7bcdc2eecaac40fb3a1f5a72cf7c7d80\\"
+        }
+      ],
+      \\"licenses\\": [
+        {
+          \\"license\\": {
+            \\"id\\": \\"MIT\\",
+            \\"text\\": {
+              \\"contentType\\": \\"text/txt\\",
+              \\"content\\": \\"The MIT License (MIT)\\\\n\\\\nCopyright (c) 2011 Rodney Rehm\\\\n\\\\nPermission is hereby granted, free of charge, to any person obtaining a copy\\\\nof this software and associated documentation files (the \\\\\\"Software\\\\\\"), to deal\\\\nin the Software without restriction, including without limitation the rights\\\\nto use, copy, modify, merge, publish, distribute, sublicense, and/or sell\\\\ncopies of the Software, and to permit persons to whom the Software is\\\\nfurnished to do so, subject to the following conditions:\\\\n\\\\nThe above copyright notice and this permission notice shall be included in\\\\nall copies or substantial portions of the Software.\\\\n\\\\nTHE SOFTWARE IS PROVIDED \\\\\\"AS IS\\\\\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\\\\nIMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\\\\nFITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\\\\nAUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\\\\nLIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\\\\nOUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\\\\nTHE SOFTWARE.\\"
+            }
+          }
+        }
+      ],
+      \\"purl\\": \\"pkg:npm/urijs@1.19.7\\",
+      \\"externalReferences\\": [
+        {
+          \\"type\\": \\"website\\",
+          \\"url\\": \\"http://medialize.github.io/URI.js/\\"
+        },
+        {
+          \\"type\\": \\"issue-tracker\\",
+          \\"url\\": \\"https://github.com/medialize/URI.js/issues\\"
+        },
+        {
+          \\"type\\": \\"vcs\\",
+          \\"url\\": \\"git+https://github.com/medialize/URI.js.git\\"
+        }
+      ]
+    }
+  ]
+}"
+`;
+
 exports[`createbom produces a BOM with development dependencies 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
 <bom xmlns=\\"http://cyclonedx.org/schema/bom/1.3\\" version=\\"1\\">

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -111,3 +111,15 @@ test('createbom produces a BOM when all dependencies are dev-dependencies that s
     done()
   })
 })
+
+test('createbom produces a BOM when there is no name in the root package', done => {
+  // test for https://github.com/CycloneDX/cyclonedx-node-module/issues/252
+  bomHelpers.createbom('library', false, true, './tests/no-name', { dev: true }, (err, bom) => {
+    expect(err).toBeFalsy()
+
+    bom.metadata.timestamp = timestamp
+    bom.metadata.tools[0].version = programVersion
+    expect(bom.toJSON()).toMatchSnapshot()
+    done()
+  })
+})

--- a/tests/no-name/README.txt
+++ b/tests/no-name/README.txt
@@ -1,0 +1,2 @@
+this test case is related to
+https://github.com/CycloneDX/cyclonedx-node-module/issues/252

--- a/tests/no-name/package-lock.json
+++ b/tests/no-name/package-lock.json
@@ -1,0 +1,40 @@
+{
+  "name": "no-name",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "packageurl-js": "^0.0.1"
+      }
+    },
+    "node_modules/packageurl-js": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-0.0.1.tgz",
+      "integrity": "sha512-hjMzq6XuAxMMiV55UOIhf6byXKR9Fc046ybroGCpjGtJ5EI9QJG9g/ErYoPt0RGUaAr51C6x+pwUG9pXgLnaqg==",
+      "dependencies": {
+        "urijs": "^1.19.1"
+      }
+    },
+    "node_modules/urijs": {
+      "version": "1.19.7",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.7.tgz",
+      "integrity": "sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA=="
+    }
+  },
+  "dependencies": {
+    "packageurl-js": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-0.0.1.tgz",
+      "integrity": "sha512-hjMzq6XuAxMMiV55UOIhf6byXKR9Fc046ybroGCpjGtJ5EI9QJG9g/ErYoPt0RGUaAr51C6x+pwUG9pXgLnaqg==",
+      "requires": {
+        "urijs": "^1.19.1"
+      }
+    },
+    "urijs": {
+      "version": "1.19.7",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.7.tgz",
+      "integrity": "sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA=="
+    }
+  }
+}

--- a/tests/no-name/package.json
+++ b/tests/no-name/package.json
@@ -1,0 +1,7 @@
+{
+  "description": "an package without a name. see https://github.com/CycloneDX/cyclonedx-node-module/issues/252",
+  "private": true,
+  "dependencies": {
+    "packageurl-js": "^0.0.1"
+  }
+}


### PR DESCRIPTION
fix #252

- [x] implement fallback for component name
- [x] add test with components without a name

Q: should a unique id added to the fallback, so possible rendering does not result in duplicate unnamed components? 
A: nope. no breaking changes intended.

Q: should the Component class have a name fallback? or should the causing `bom.metadata.component` be fixed instead? 
A: nope. root component is the only thing that must be fixed right now.