### PR TITLE
Ensure license text persists linting

### DIFF
--- a/bin/make-bom.js
+++ b/bin/make-bom.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint-env node */
 
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/AttachmentText.js
+++ b/model/AttachmentText.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/Bom.js
+++ b/model/Bom.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/Component.js
+++ b/model/Component.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/CycloneDXObject.js
+++ b/model/CycloneDXObject.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/Dependency.js
+++ b/model/Dependency.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/ExternalReference.js
+++ b/model/ExternalReference.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/ExternalReferenceList.js
+++ b/model/ExternalReferenceList.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/Hash.js
+++ b/model/Hash.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/HashList.js
+++ b/model/HashList.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/License.js
+++ b/model/License.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/LicenseChoice.js
+++ b/model/LicenseChoice.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/Metadata.js
+++ b/model/Metadata.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/OrganizationalContact.js
+++ b/model/OrganizationalContact.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/OrganizationalEntity.js
+++ b/model/OrganizationalEntity.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/Swid.js
+++ b/model/Swid.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/model/Tool.js
+++ b/model/Tool.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/complex.test.js
+++ b/tests/integration/complex.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/index.test.js
+++ b/tests/integration/index.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/integration/setup.js
+++ b/tests/integration/setup.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/model/Bom.test.js
+++ b/tests/model/Bom.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/model/Component.test.js
+++ b/tests/model/Component.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/model/ExternalReference.test.js
+++ b/tests/model/ExternalReference.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/model/ExternalReferenceList.test.js
+++ b/tests/model/ExternalReferenceList.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/model/Metadata.test.js
+++ b/tests/model/Metadata.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/model/OrganizationalContact.test.js
+++ b/tests/model/OrganizationalContact.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-/*
+/*!
  * This file is part of CycloneDX Node Module.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Closes #305: In the JavaScript ecosystem, it is common to bundle or
minify code. During these processes, it is common to remove code
comments. Prefix license comment blocks with “/*!” to signal to these
tools that the license comment block should not be removed.

Signed-off-by: William E Little Jr <git@bmo.dev>