### PR TITLE
docs: add rollup-plugin-sbom to out of scope section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ These systems are out of scope. Therefore, the following tools are not part of t
 | _React_ | [@cyclonedx/webpack-plugin with React](https://www.npmjs.com/package/@cyclonedx/webpack-plugin?activeTab=readme#user-content-use-with-react) |
 | _Svelte_ | To be announced, suggestions welcome |
 | _Parcel_ | To be announced, suggestions welcome |
+| _Rollup_ | [rollup-plugin-sbom](https://www.npmjs.com/package/rollup-plugin-sbom?activeTab=readme) |
+| _Vite_ | [rollup-plugin-sbom with Vite](https://www.npmjs.com/package/rollup-plugin-sbom?activeTab=readme#usage-with-vite) |
 | _Bower_ | None. (_Bower_ is [deprecated](https://bower.io/blog/2017/how-to-migrate-away-from-bower/)!) |
 
 ## Library


### PR DESCRIPTION
As recommended by @jkowalleck in https://github.com/CycloneDX/cyclonedx.org/pull/289#issuecomment-2093244718, the addition of [rollup-plugin-sbom](https://github.com/janbiasi/rollup-plugin-sbom) in the "out of scope" section of the readme file for the Rollup and Vite ecosystem.